### PR TITLE
"import unirec" runs under python2 and python3

### DIFF
--- a/python/unirec/unirec.py
+++ b/python/unirec/unirec.py
@@ -208,9 +208,9 @@ def CreateTemplate(template_name, field_names, verbose=False):
    # Execute the template string in a temporary namespace
    namespace = {'IPAddr':IPAddr, 'Timestamp':Timestamp}
    try:
-      exec class_code in namespace
-      if verbose: print class_code
-   except SyntaxError, e:
+      exec(class_code) in namespace
+      if verbose: print(class_code)
+   except SyntaxError as e:
       raise SyntaxError(e.message + ':\n' + class_code)
    cls = namespace[template_name]
    # For pickling to work, the __module__ variable needs to be set to the frame

--- a/python/unirec/ur_ipaddr.py
+++ b/python/unirec/ur_ipaddr.py
@@ -10,6 +10,10 @@ TODO: creation of IP4Range/IP6Range using address-netmask notation,
 
 from collections import namedtuple as _nt
 import struct
+import sys
+
+if sys.version_info > (3,):
+   long = int
 
 __all__ = ['IPAddr', 'IP4Addr', 'IP6Addr', 'IPRange', 'IP4Range', 'IP6Range']
 
@@ -78,7 +82,7 @@ class IP4Addr(IPAddr):
    """
    __slots__ = ()
 
-   def __new__(cls, val = 0L):
+   def __new__(cls, val = long(0)):
       if isinstance(val, IP4Addr):
          return val
       elif isinstance(val, long) or isinstance(val, int):
@@ -157,7 +161,7 @@ class IP6Addr(IPAddr):
    """
    __slots__ = ()
 
-   def __new__(cls, val = 0L):
+   def __new__(cls, val = long(0)):
       if isinstance(val, IP6Addr):
          return val
       elif isinstance(val, long) or isinstance(val, int):
@@ -321,13 +325,13 @@ class IPRange(IPRangeParentType):
       if isinstance(base, IP4Addr):
          if not 0 <= prefix_len <= 32:
             raise ValueError("Length of IPv4 prefix must be between 0 and 32.")
-         start = base &  (~0L << (32-prefix_len))
-         end   = base | ~(~0L << (32-prefix_len))
+         start = base &  (~long(0) << (32-prefix_len))
+         end   = base | ~(~long(0) << (32-prefix_len))
       else:
          if not 0 <= prefix_len <= 128:
             raise ValueError("Length of IPv6 prefix must be between 0 and 128.")
-         start = base &  (~0L << (128-prefix_len))
-         end   = base | ~(~0L << (128-prefix_len))
+         start = base &  (~long(0) << (128-prefix_len))
+         end   = base | ~(~long(0) << (128-prefix_len))
       return cls.fromPair(start, end)
 
 
@@ -469,7 +473,7 @@ if __name__ == '__main__':
          self.assertRaises(TypeError, IPAddr, 0.5)
          self.assertRaises(TypeError, IPAddr, (1,2))
 
-   print "IP Address module - self testing:"
+   print("IP Address module - self testing:")
    unittest.main()
 
 

--- a/python/unirec/ur_time.py
+++ b/python/unirec/ur_time.py
@@ -6,6 +6,10 @@ from datetime import datetime
 import time
 import calendar
 import re
+import sys
+
+if sys.version_info > (3,):
+   long = int
 
 MSEC_TO_FRAC = 0b01000001100010010011011101001011110001101010011111101111 # 2**32 / 1000 in fixed-point
 FRAC_TO_MSEC = 0b1111101001 # 1000 / 2**32 in fixed-point


### PR DESCRIPTION
Made some changes to run "import unirec" in both python versions (print and exec changed to functions, issue with long data type solved)