### PR TITLE
libtrap sockets

### DIFF
--- a/libtrap/Makefile.am
+++ b/libtrap/Makefile.am
@@ -53,6 +53,9 @@ endif
 deb-clean:
 	rm -rf libtrap_*.build libtrap_*.changes libtrap_*.deb libtrap-dev_*.deb libtrap_*.orig.tar.gz libtrap-*.tar.gz libtrap-@VERSION@
 
+install-exec-hook:
+	mkdir -p $(DESTDIR)/$(DEFAULTSOCKETDIR) && chmod 1777 $(DESTDIR)/$(DEFAULTSOCKETDIR) || true
+
 changelog:
 	echo -e "This will insert history into ChangeLog file and open NEWS in vim.\nC-c to interrupt."; \
 	git log --date=short --format="%cd (%an): %s" $(shell git tag | head -1)..HEAD . > chlog.tmp; \

--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([libtrap], [0.8.1], [traffic-analysis@cesnet.cz])
+AC_INIT([libtrap], [0.9.0], [nemea@cesnet.cz])
 #for debug purposes:
 #AM_INIT_AUTOMAKE([-Wall -Werror])
 AM_INIT_AUTOMAKE([subdir-objects no-dependencies])

--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -29,6 +29,14 @@ AC_ARG_ENABLE([debug],
 
 LT_INIT()
 
+AC_ARG_WITH([defaultsocketdir],
+	[AS_HELP_STRING([--with-defaultsocketdir=DIR], [Directory for UNIX&service IFCs [/tmp], for production set it to e.g. /var/run/libtrap.])],
+	[],
+	[with_defaultsocketdir=/tmp])
+
+AC_SUBST([defaultsocketdir], [$with_defaultsocketdir])
+AC_DEFINE_DIR([DEFAULTSOCKETDIR], [defaultsocketdir], [Default path to socket directory])
+
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O

--- a/libtrap/include/libtrap/trap.h
+++ b/libtrap/include/libtrap/trap.h
@@ -76,6 +76,11 @@ extern const char trap_version[];
 extern const char trap_git_version[];
 
 /**
+ * Text string with default path to sockets (UNIX IFC and service IFC).
+ */
+extern const char trap_default_socket_path[];
+
+/**
  * \defgroup errorcodes Error codes
  * @{*/
 #define TRAP_E_OK 0 ///< Success, no error

--- a/libtrap/libtrap.spec.in
+++ b/libtrap/libtrap.spec.in
@@ -29,7 +29,7 @@ if you want to develop your own TRAP module.
 %setup
 
 %build
-./configure --prefix=%{_prefix} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --docdir=%{_docdir}/libtrap --disable-doxygen-pdf --disable-doxygen-ps --disable-tests -q;
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --docdir=%{_docdir}/libtrap --with-defaultsocketdir=%{_localstatedir}/run/libtrap --disable-doxygen-pdf --disable-doxygen-ps --disable-tests -q;
 make -j5
 make doc
 
@@ -42,6 +42,8 @@ ldconfig
 %files
 %{_bindir}/nemea/trap_stats
 %{_libdir}/libtrap.so.*
+%defattr(-,-,-,1777)
+%dir %{_localstatedir}/run/libtrap
 
 %files devel
 %{_libdir}/pkgconfig/libtrap.pc

--- a/libtrap/m4/ac_define_dir.m4
+++ b/libtrap/m4/ac_define_dir.m4
@@ -1,0 +1,34 @@
+dnl @synopsis AC_DEFINE_DIR(VARNAME, DIR [, DESCRIPTION])
+dnl
+dnl This macro sets VARNAME to the expansion of the DIR variable,
+dnl taking care of fixing up ${prefix} and such.
+dnl
+dnl VARNAME is then offered as both an output variable and a C
+dnl preprocessor symbol.
+dnl
+dnl Example:
+dnl
+dnl    AC_DEFINE_DIR([DATADIR], [datadir], [Where data are placed to.])
+dnl
+dnl @category Misc
+dnl @author Stepan Kasal <kasal@ucw.cz>
+dnl @author Andreas Schwab <schwab@suse.de>
+dnl @author Guido U. Draheim <guidod@gmx.de>
+dnl @author Alexandre Oliva
+dnl @version 2006-10-13
+dnl @license AllPermissive
+
+AC_DEFUN([AC_DEFINE_DIR], [
+  prefix_NONE=
+  exec_prefix_NONE=
+  test "x$prefix" = xNONE && prefix_NONE=yes && prefix=$ac_default_prefix
+  test "x$exec_prefix" = xNONE && exec_prefix_NONE=yes && exec_prefix=$prefix
+dnl In Autoconf 2.60, ${datadir} refers to ${datarootdir}, which in turn
+dnl refers to ${prefix}.  Thus we have to use `eval' twice.
+  eval ac_define_dir="\"[$]$2\""
+  eval ac_define_dir="\"$ac_define_dir\""
+  AC_SUBST($1, "$ac_define_dir")
+  AC_DEFINE_UNQUOTED($1, "$ac_define_dir", [$3])
+  test "$prefix_NONE" && prefix=NONE
+  test "$exec_prefix_NONE" && exec_prefix=NONE
+])

--- a/libtrap/src/ifc_tcpip.h
+++ b/libtrap/src/ifc_tcpip.h
@@ -51,12 +51,14 @@
  */
 #define TCPIP_IFC_PARAMS_DELIMITER  (',')
 
+#ifndef UNIX_PATH_FILENAME_FORMAT
 /**
  * Communication via UNIX socket needs to specify path to socket file.
  * It is currently placed according to this format, where %s is replaced by
  * port given as an argument of TCPIP IFC.
  */
-#define UNIX_PATH_FILENAME_FORMAT   "/tmp/trap-localhost-%s.sock"
+#define UNIX_PATH_FILENAME_FORMAT   DEFAULTSOCKETDIR "/localhost-%s.sock"
+#endif
 
 /**
  * Type of socket that is used for the TRAP interface.

--- a/libtrap/src/ifc_tcpip.h
+++ b/libtrap/src/ifc_tcpip.h
@@ -57,7 +57,7 @@
  * It is currently placed according to this format, where %s is replaced by
  * port given as an argument of TCPIP IFC.
  */
-#define UNIX_PATH_FILENAME_FORMAT   DEFAULTSOCKETDIR "/localhost-%s.sock"
+#define UNIX_PATH_FILENAME_FORMAT   DEFAULTSOCKETDIR "/trap-%s.sock"
 #endif
 
 /**

--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -89,6 +89,13 @@ const char trap_version[] __attribute__((used)) = PACKAGE_VERSION;
 const char trap_git_version[] __attribute__((used)) = GIT_VERSION;
 
 /**
+ * Default path to socket directory.
+ *
+ * UNIX sockets are created here for service IFC as well as for UNIX IFC type.
+ */
+const char trap_default_socket_path[] __attribute__((used)) = DEFAULTSOCKETDIR;
+
+/**
  * Print Trap IFC help in trap_print_help() if non-zero.
  */
 char trap_help_spec = 0;


### PR DESCRIPTION
Change fixed location of libtrap sockets to DEFAULTSOCKETDIR, configured by --with-defaultsocketdir=DIR. This closes #27.

The default path was left to /tmp because it causes problems with local build & check.

For RPM packages, the path is set to /var/run/libtrap.

Before creation RPM package at copr, supervisor MUST be fixed to use the correct path (it is accessible by trap_default_socket_path global variable. The format for creating socket names was changed to "trap-%s.sock" that is a little bit shorter, `localhost` did not make sense. 