### PR TITLE
libtrap: fixed 100% cpu load bug, closes #31

### DIFF
--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -1490,7 +1490,7 @@ inline char *get_param_by_delimiter(const char *source, char **dest, const char 
    return trap_get_param_by_delimiter(source, dest, delimiter);
 }
 
-void trap_set_abs_timespec(int timeout, struct timeval *tm, struct timespec *tmnblk)
+void trap_set_abs_timespec(struct timeval *tm, struct timespec *tmnblk)
 {
    if (tmnblk == NULL) {
       /* we do not need tmnblk */
@@ -1528,7 +1528,7 @@ void trap_set_timeouts(int timeout, struct timeval *tm, struct timespec *tmnblk)
       VERBOSE(CL_ERROR, "Setting timeout to %d failed", timeout);
       return;
    }
-   trap_set_abs_timespec(timeout, tm, tmnblk);
+   trap_set_abs_timespec(tm, tmnblk);
 }
 
 int trap_ifcctl(int8_t type, uint32_t ifcidx, int32_t request, ... /* arg */)

--- a/libtrap/src/trap_ifc.h
+++ b/libtrap/src/trap_ifc.h
@@ -283,11 +283,10 @@ void trap_set_timeouts(int timeout, struct timeval *tm, struct timespec *tmnblk)
 /**
  * \brief Internal function for setting of timeout structs according to libtrap timeout.
  *
- * \param[in] timeout  Amount of time / timeout that is being converted.
  * \param[in] tm       Precomputed timeval, set using e.g. trap_set_timeouts().
  * \param[out] tmnblk  Used for sem_timedwait() call to block on semaphore.
  */
-void trap_set_abs_timespec(int timeout, struct timeval *tm, struct timespec *tmnblk);
+void trap_set_abs_timespec(struct timeval *tm, struct timespec *tmnblk);
 
 /**
  * @}


### PR DESCRIPTION
   * absolute time used on sem_timedwait should be properly set now
   * new absolute time is computed when blocking is repeated
   * removed `int timeout` from trap_set_abs_timespec function