### PR TITLE
removed unnecessary code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The framework consists of:
  * [libtrap](./libtrap) -- communication interface for messages transfer between Nemea modules
  * [UniRec](./unirec) -- flexible and efficient data format of flow-records
  * [common](./common) -- usefull common functions and data structures
- * [python](./python) -- python wrapper for libtrap and UniRec that allows development of nemea modules in python
+ * [pytrap](./pytrap) -- python wrapper for libtrap and UniRec that allows development of nemea modules in python
  * [pycommon](./pycommon) -- python common modules and methods, there is currently a support of alerts creation in the [IDEA](https://idea.cesnet.cz/en/index) format that can be stored into MongoDB or sent to the [Warden](https://wardenw.cesnet.cz/) incident sharing system
 
 
@@ -36,7 +36,7 @@ Python parts must be installed separately when needed.
 It can be done using:
 
 ```
-cd python; sudo python setup.py install
+cd pytrap; sudo python setup.py install
 ```
 and
 ```

--- a/pycommon/report2idea.py
+++ b/pycommon/report2idea.py
@@ -30,8 +30,7 @@ def getIDEAtime(unirecField = None):
         ts = unirecField.toDatetime()
         return ts.strftime('%Y-%m-%dT%H:%M:%SZ')
     else:
-        t = time()
-        g = gmtime(t)
+        g = gmtime()
         iso = '%04d-%02d-%02dT%02d:%02d:%02dZ' % g[0:6]
     return iso
 
@@ -296,4 +295,3 @@ def Run(module_name, module_desc, req_type, req_format, conv_func, arg_parser = 
     if wardenclient:
         wardenclient.close()
     trap.finalize()
-


### PR DESCRIPTION
**gmtime()**
Convert a time expressed in seconds since the epoch to a struct_time in UTC in which the dst flag is always zero. **If secs is not provided or None, the current time as returned by time() is used.**