### PR TITLE
libtrap: return values in tls and tcpip interfaces fixed; closes #82

### DIFF
--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -87,6 +87,7 @@ if test x$have_openssl = xyes; then
   CXXFLAGS="$openssl_CFLAGS $CXXFLAGS"
 else
   AC_DEFINE([HAVE_OPENSSL], [0], [Define to 1 if the openssl is available])
+  AC_MSG_WARN([OpenSSL not found. You will not be able to use secure TLS interface.])
 fi
 
 # Checks for header files.

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -802,7 +802,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
    int sockfd = -1, options;
    union tcpip_socket_addr addr;
    struct addrinfo *servinfo, *p = NULL;
-   int rv = 0, addr_count = 0;
+   int rv, addr_count = 0;
    char s[INET6_ADDRSTRLEN];
 
    if ((config == NULL) || (dest_addr == NULL) || (dest_port == NULL) || (socket_descriptor == NULL)) {
@@ -891,6 +891,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
          } else {
             p = (struct addrinfo *) &addr.unix_addr;
          }
+        rv = TRAP_E_OK;
       } else {
          rv = TRAP_E_IO_ERROR;
       }

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -2,12 +2,10 @@
  * \file ifc_tcpip.c
  * \brief TRAP TCP/IP interfaces
  * \author Tomas Cejka <cejkat@cesnet.cz>
- * \date 2013
- * \date 2014
- * \date 2015
+ * \date 2018
  */
 /*
- * Copyright (C) 2013-2015 CESNET
+ * Copyright (C) 2013-2018 CESNET
  *
  * LICENSE TERMS
  *
@@ -844,8 +842,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
          if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
             continue;
          }
-         options = fcntl(sockfd, F_GETFL);
-         if (options != -1) {
+         if ((options = fcntl(sockfd, F_GETFL)) != -1) {
             if (fcntl(sockfd, F_SETFL, O_NONBLOCK | options) == -1) {
                VERBOSE(CL_ERROR, "Could not set socket to non-blocking.");
             }
@@ -877,8 +874,9 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
       }
 
       if (p != NULL) {
-         inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), s, sizeof s);
-         VERBOSE(CL_VERBOSE_LIBRARY, "recv client: connected to %s", s);
+         if (inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), s, sizeof s) != NULL) {
+            VERBOSE(CL_VERBOSE_LIBRARY, "recv client: connected to %s", s);
+         }
       }
       freeaddrinfo(servinfo); // all done with this structure
    } else if (config->socket_type == TRAP_IFC_TCPIP_UNIX) {

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -804,7 +804,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
    int sockfd = -1, options;
    union tcpip_socket_addr addr;
    struct addrinfo *servinfo, *p = NULL;
-   int rv, addr_count = 0;
+   int rv = 0, addr_count = 0;
    char s[INET6_ADDRSTRLEN];
 
    if ((config == NULL) || (dest_addr == NULL) || (dest_port == NULL) || (socket_descriptor == NULL)) {
@@ -894,13 +894,17 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
             p = (struct addrinfo *) &addr.unix_addr;
          }
       } else {
-         return TRAP_E_IO_ERROR;
+         rv = TRAP_E_IO_ERROR;
       }
    }
 
    if (p == NULL) {
       VERBOSE(CL_VERBOSE_LIBRARY, "recv client: Connection failed.");
-      return TRAP_E_TIMEOUT;
+      rv = TRAP_E_TIMEOUT;
+   }
+
+   if (rv != TRAP_E_OK) { /*something went wrong while setting up connection */
+      return rv;
    }
 
    *socket_descriptor = sockfd;
@@ -945,7 +949,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
 #endif
 
 
-   return TRAP_E_OK;
+   return rv;
 }
 
 /**

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1028,8 +1028,9 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
    }
 
    if (p != NULL) {
-      inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), s, sizeof s);
-      VERBOSE(CL_VERBOSE_LIBRARY, "recv client: connected to %s", s);
+      if (inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), s, sizeof s) != NULL) {
+         VERBOSE(CL_VERBOSE_LIBRARY, "recv client: connected to %s", s);
+      }
    }
    CHECK_AND_FREE(servinfo, freeaddrinfo); /* all done with this structure */
 

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -3,13 +3,10 @@
  * \brief TRAP TCP with TLS interfaces
  * \author Tomas Cejka <cejkat@cesnet.cz>
  * \author Jaroslav Hlavac <hlavaj20@fit.cvut.cz>
- * \date 2013
- * \date 2014
- * \date 2015
- * \date 2017
+ * \date 2018
  */
 /*
- * Copyright (C) 2013-2017 CESNET
+ * Copyright (C) 2013-2018 CESNET
  *
  * LICENSE TERMS
  *
@@ -955,10 +952,7 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
    int rv, addr_count = 0;
    char s[INET6_ADDRSTRLEN];
 
-   if (c == NULL) {
-      return TRAP_E_BAD_FPARAMS;
-   }
-   if ((c->dest_addr == NULL) || (c->dest_port == NULL)) {
+   if ((c == NULL) || (c->dest_addr == NULL) || (c->dest_port == NULL)) {
       return TRAP_E_BAD_FPARAMS;
    }
 
@@ -991,8 +985,7 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
       if ((sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
          continue;
       }
-      options = fcntl(sockfd, F_GETFL);
-      if (options != -1) {
+      if ((options = fcntl(sockfd, F_GETFL)) != -1) {
          if (fcntl(sockfd, F_SETFL, O_NONBLOCK | options) == -1) {
             VERBOSE(CL_ERROR, "Could not set socket to non-blocking.");
          }

--- a/libtrap/tests/Makefile.am
+++ b/libtrap/tests/Makefile.am
@@ -1,5 +1,5 @@
-normal_tests_scripts=basic_test_arg.test basic_test_timeouts.test libtrap_disbuffer.test test_service_ifc_fail.test test_tls.sh
-long_tests_scripts=libtrap_simpleapi.test libtrap_ctxapi.test libtrap_simpleapi_t.test libtrap_ctxapi_t.test libtrap_tls.test
+normal_tests_scripts=basic_test_arg.test basic_test_timeouts.test libtrap_disbuffer.test test_service_ifc_fail.test
+long_tests_scripts=libtrap_simpleapi.test libtrap_ctxapi.test libtrap_simpleapi_t.test libtrap_ctxapi_t.test
 
 normal_tests_progs=test_badparams test_finalize test_blackhole test_fileifc
 
@@ -16,6 +16,9 @@ TESTS = $(normal_tests)
 
 if ENABLE_LONG_TESTS
 TESTS += $(long_tests)
+if HAVE_OPENSSL
+TESTS += libtrap_tls.test
+endif
 endif
 
 
@@ -26,6 +29,10 @@ check_PROGRAMS = basic_test $(normal_tests_progs)
 if HAVE_CMOCKA
 TESTS += $(cmockadep_tests_progs)
 check_PROGRAMS += $(cmockadep_tests_progs)
+endif
+
+if HAVE_OPENSSL
+TESTS += test_tls.sh
 endif
 
 noinst_PROGRAMS = test_tcpip_wclient test_tcpip_wserver test_tcpip_nb5client test_tcpip_nb5server test_tcpip_client test_tcpip_server test_echo test_echo_reply test_echo_ctx test_echo_reply_ctx test_parse_params test_timeouts valid_buffer test_rxtx test_multi_recv


### PR DESCRIPTION
Added check for return value of tcp socket connection to both interfaces. If it failed, function will end with proper TRAP error code.

Fixed problem with not notifying user that libtrap will be installed without tls interface and then failing on executing tests for tls.

Few minor coding style changes.