### PR TITLE
libtrap: bugfix: "Trap error: No error" solved

### DIFF
--- a/libtrap/include/libtrap/trap.h
+++ b/libtrap/include/libtrap/trap.h
@@ -657,7 +657,7 @@ void trap_send_flush(uint32_t ifc);
  * \param[in] module_info     Pointer to struct containing info about the module.
  * \param[in] ifc_spec        Structure with specification of interface types and
  *                      their parameters.
- * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
+ * \return Pointer to context (context needs to be checked for error value by trap_ctx_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init(trap_module_info_t *module_info, trap_ifc_spec_t ifc_spec);
 
@@ -668,7 +668,7 @@ trap_ctx_t *trap_ctx_init(trap_module_info_t *module_info, trap_ifc_spec_t ifc_s
  * \param[in] ifc_spec         Structure with specification of interface types and their parameters.
  * \param[in] service_ifcname  Identifier of the service IFC (used as a part of path to the UNIX socket). When NULL is used, no service IFC will be opened.
  *
- * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
+ * \return Pointer to context (context needs to be checked for error value by trap_ctx_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init2(trap_module_info_t *module_info, trap_ifc_spec_t ifc_spec, const char *service_ifcname);
 
@@ -682,7 +682,7 @@ trap_ctx_t *trap_ctx_init2(trap_module_info_t *module_info, trap_ifc_spec_t ifc_
  * \param[in] ifc_spec  IFC_SPEC stringdescribed in README.ifcspec.md
  * \param[in] service_ifcname Identifier of the service IFC (used as a part of path to the UNIX socket). When NULL is used, no service IFC will be opened.
  *
- * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
+ * \return Pointer to context (context needs to be checked for error value by trap_ctx_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init3(const char *name, const char *description, int8_t i_ifcs, int8_t o_ifcs, const char *ifc_spec, const char *service_ifcname);
 

--- a/libtrap/include/libtrap/trap.h
+++ b/libtrap/include/libtrap/trap.h
@@ -657,7 +657,7 @@ void trap_send_flush(uint32_t ifc);
  * \param[in] module_info     Pointer to struct containing info about the module.
  * \param[in] ifc_spec        Structure with specification of interface types and
  *                      their parameters.
- * \return Pointer to the allocated private libtrap context data.
+ * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init(trap_module_info_t *module_info, trap_ifc_spec_t ifc_spec);
 
@@ -668,7 +668,7 @@ trap_ctx_t *trap_ctx_init(trap_module_info_t *module_info, trap_ifc_spec_t ifc_s
  * \param[in] ifc_spec         Structure with specification of interface types and their parameters.
  * \param[in] service_ifcname  Identifier of the service IFC (used as a part of path to the UNIX socket). When NULL is used, no service IFC will be opened.
  *
- * \return Pointer to context, NULL on error.
+ * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init2(trap_module_info_t *module_info, trap_ifc_spec_t ifc_spec, const char *service_ifcname);
 
@@ -682,7 +682,7 @@ trap_ctx_t *trap_ctx_init2(trap_module_info_t *module_info, trap_ifc_spec_t ifc_
  * \param[in] ifc_spec  IFC_SPEC stringdescribed in README.ifcspec.md
  * \param[in] service_ifcname Identifier of the service IFC (used as a part of path to the UNIX socket). When NULL is used, no service IFC will be opened.
  *
- * \return Pointer to context, NULL on error.
+ * \return Pointer to context (context needs to be checked for error value by trap_get_last_error() function), NULL on memory error.
  */
 trap_ctx_t *trap_ctx_init3(const char *name, const char *description, int8_t i_ifcs, int8_t o_ifcs, const char *ifc_spec, const char *service_ifcname);
 

--- a/libtrap/tests/basic_test.c
+++ b/libtrap/tests/basic_test.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
   fprintf(stderr, "Test 01:\n");
   trap_parse_params(&argc, argv, &ifc_spec);
   trap_ctx_t *ctx = trap_ctx_init(&module_info, ifc_spec);
-  if (ctx == NULL) {
+  if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
      fprintf(stderr, "Failed trap_ctx_init.\n");
      return 1;
   }
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
 
   fprintf(stderr, "Test 02:\n");
   ctx = trap_ctx_init2(&module_info, ifc_spec, "abcdef");
-  if (ctx == NULL) {
+  if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
      fprintf(stderr, "Failed trap_ctx_init.\n");
      return 1;
   }
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 
   fprintf(stderr, "Test 03:\n");
   ctx = trap_ctx_init3("testmodule", "test description", 1, 1, "u:test-input-ifc,u:test-output-ifc", "test-service-ifc");
-  if (ctx == NULL) {
+  if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
      fprintf(stderr, "Failed trap_ctx_init.\n");
      return 1;
   }
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
   fprintf(stderr, "Test 04: (illegal character in service IFC name))\n");
   ctx = trap_ctx_init2(&module_info, ifc_spec, "a/b");
-  if (ctx == NULL) {
+  if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
      fprintf(stderr, "Failed trap_ctx_init.\n");
      return 1;
   }
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 
   fprintf(stderr, "Test 05: (disabled service IFC))\n");
   ctx = trap_ctx_init2(&module_info, ifc_spec, NULL);
-  if (ctx == NULL) {
+  if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
      fprintf(stderr, "Failed trap_ctx_init.\n");
      return 1;
   }

--- a/libtrap/tests/out-buf.c
+++ b/libtrap/tests/out-buf.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
    trap_ifc_spec_t ifc_spec = {"u", params_a};
    trap_ctx_t *ctx = trap_ctx_init(&module_info, ifc_spec);
    trap_ctx_priv_t *cp = ctx;
-   if (ctx == NULL) {
+   if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
       errx(trap_last_error, trap_last_error_msg);
    }
 

--- a/libtrap/tests/test_blackhole.c
+++ b/libtrap/tests/test_blackhole.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
 {
    uint64_t i;
    trap_ctx_t *ctx = trap_ctx_init3("testmodule", "test description", 0, 1, "b:", "test-service-ifc");
-   if (ctx == NULL) {
+   if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
       fprintf(stderr, "Failed trap_ctx_init.\n");
       return 1;
    }

--- a/libtrap/tests/test_fileifc.c
+++ b/libtrap/tests/test_fileifc.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
    int ret = 0;
 
    trap_ctx_t *ctx = trap_ctx_init3("testmodule", "test description", 0, 1, "f:" DATAFILE ":w", NULL);
-   if (ctx == NULL) {
+   if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
       fprintf(stderr, "Failed trap_ctx_init.\n");
       return 1;
    }
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
    trap_ctx_finalize(&ctx);
 
    ctx = trap_ctx_init3("testmodule", "test description", 1, 0, "f:" DATAFILE, NULL);
-   if (ctx == NULL) {
+   if (ctx == NULL || trap_ctx_get_last_error(ctx) != TRAP_E_OK) {
       fprintf(stderr, "Failed trap_ctx_init.\n");
       return 1;
    }

--- a/libtrap/tests/test_finalize.c
+++ b/libtrap/tests/test_finalize.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
    // Since we do not need this structure anymore ...
    trap_free_ifc_spec(in_ifc_spec);
 
-   if (in_ctx == NULL) {
+   if (in_ctx == NULL || trap_ctx_get_last_error(in_ctx) != TRAP_E_OK) {
       fprintf(stderr, "Error: Error in TRAP initialization (input context): %s\n", trap_last_error_msg);
       return EXIT_FAILURE;
    }
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
       // Since we do not need this structure anymore ...
       trap_free_ifc_spec(out_ifc_spec);
 
-      if (out_ctx == NULL) {
+      if (out_ctx == NULL || trap_ctx_get_last_error(out_ctx) != TRAP_E_OK) {
          fprintf(stderr, "Error: Error in TRAP initialization (output context): %s\n", trap_last_error_msg);
          return EXIT_FAILURE;
       }

--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -124,7 +124,7 @@ pytrap_init(pytrap_trapcontext *self, PyObject *args, PyObject *keywds)
                                 ifc_spec,
                                 service_ifcname);
 
-    if (self->trap == NULL) {
+    if (self->trap == NULL || trap_get_last_error(self->trap)) {
         PyErr_SetString(TrapError, "Initialization failed");
         return NULL;
     }

--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -124,7 +124,7 @@ pytrap_init(pytrap_trapcontext *self, PyObject *args, PyObject *keywds)
                                 ifc_spec,
                                 service_ifcname);
 
-    if (self->trap == NULL || trap_get_last_error(self->trap)) {
+    if (self->trap == NULL || trap_ctx_get_last_error(self->trap) != TRAP_E_OK) {
         PyErr_SetString(TrapError, "Initialization failed");
         return NULL;
     }


### PR DESCRIPTION
The problem was in the function trap_ctx_init2, where it would destroy the context in every scenario, where TRAP_E_OK did not happen and subsequently returned NULL. However, the calling function trap_init expected NULL only when TRAP_E_MEMORY occurred. This resulted in almost dead code in trap_init function checking other errors. This error in combination with improper setting of error codes in other functions resulted in bad value in error code and error string.