### PR TITLE
libtrap: BUGFIX free error strings from OpenSSL

### DIFF
--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -186,6 +186,7 @@ void trap_free_global_vars(void)
 
 #if HAVE_OPENSSL
    EVP_cleanup();
+   ERR_free_strings();
 #endif
 }
 


### PR DESCRIPTION
Loaded strings for OpenSSL error messages were not freed.
This patch solves memory leak.