### PR TITLE
trap_stats: improved input - path to socket

### DIFF
--- a/libtrap/tools/trap_stats.c
+++ b/libtrap/tools/trap_stats.c
@@ -386,7 +386,7 @@ void signal_handler(int catched_signal)
 void print_help(char *prog)
 {
    printf("Usage:  %s  [-s service_socket_path] [socket_identifier]\n", prog);
-   printf("Pass the path to a service socket as an argument of -s. The option -s can be ommitted. When only PID of is given instead of full path, the default path is probed.\n");
+   printf("Pass the path to a service socket as an argument of -s. The option -s can be ommitted. When only PID is given instead of full path, the default path is probed.\n");
    printf("\nOptional parameters:\n");
    printf("\t-1\t- quit after first read\n");
    printf("\nExamples:\n\t%s -s /var/run/libtrap/trap-service_31270.sock\n", prog);


### PR DESCRIPTION
It is now possible to use `trap_stats` without `-s` with just PID
or path to socket.

Examples:

```
trap_stats 31270
trap_stats /var/run/libtrap/trap-service_31270.sock
```

The `-s` naturally exists for the backwards compatibility.