### PR TITLE
libtrap: bugfix in TCPIP interface

### DIFF
--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1809,6 +1809,7 @@ refuse_client:
                      c->connected_clients, c->clients_arr_size);
                shutdown(newclient, SHUT_RDWR);
                close(newclient);
+               cl->sd = -1;
             }
             pthread_mutex_unlock(&c->lock);
          }


### PR DESCRIPTION
After a socket was closed because of unsuccessful negotiation,
it was not set to -1. This caused other functions to treat the socket as valid.
Such bahevior resulted in situation where this socket was passed to select() function.
Select() function returns EBADF when a bad file descriptor is passed.
Further fucntions subsequently segfaulted.