### PR TITLE
Explicit conversion from int to char

### DIFF
--- a/common/configurator/configurator-internal.h
+++ b/common/configurator/configurator-internal.h
@@ -86,9 +86,9 @@ static const char varTypeSize[] = {
     sizeof(int64_t),
     sizeof(float),
     sizeof(double),
-    -1, // String, size is computed based on specified max size.
-    -1, // Struct, size is computed based on specified elements.
-    -1  // Array, size is computed based on specified elements.
+    (char) -1, // String, size is computed based on specified max size.
+    (char) -1, // Struct, size is computed based on specified elements.
+    (char) -1  // Array, size is computed based on specified elements.
 };
 
 /**


### PR DESCRIPTION
This pull request fixes an issue that happens during building Nemea-Framework on Raspberry Pi:

_make[5]: Entering directory '/home/pi/projects/nemea/nemea-framework/common'
  CXX      configurator/configurator.lo
In file included from configurator/configurator.cpp:59:0:
configurator/configurator-internal.h:92:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]
 };_