### PR TITLE
Reader threads may hang on sem_wait if the semaphore is uninitialized

### DIFF
--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -2321,15 +2321,16 @@ trap_ctx_t *trap_ctx_init2(trap_module_info_t *module_info, trap_ifc_spec_t ifc_
          }
          dataarg->ctx = ctx;
          dataarg->thread_index = i;
+         if (sem_init(&ctx->reader_threads[i].sem, SEM_PSHARED, 0) != 0) {
+            VERBOSE(CL_ERROR, "Creation of reader semaphore failed.");
+            trap_errorf(ctx, TRAP_E_MEMORY, "Creation of reader semaphore failed.");
+            goto freein_readers;
+         }
+
          if (pthread_create(&ctx->reader_threads[i].thr, NULL, reader_threads_fn, (void *) dataarg) != 0) {
             VERBOSE(CL_ERROR, "Creation of reader thread failed.");
             trap_errorf(ctx, TRAP_E_MEMORY, "Creation of reader thread failed.");
             free(dataarg);
-            goto freein_readers;
-         }
-         if (sem_init(&ctx->reader_threads[i].sem, SEM_PSHARED, 0) != 0) {
-            VERBOSE(CL_ERROR, "Creation of reader semaphore failed.");
-            trap_errorf(ctx, TRAP_E_MEMORY, "Creation of reader semaphore failed.");
             goto freein_readers;
          }
       }


### PR DESCRIPTION
Creating threads before initializing semaphores the threads wait on is obviously mistake and it results in deadlocks. For instance: if one would use 3 input interfaces and then call trap_ctx_finalize(), the function would call trap_free_ctx_t() which would hang on pthread_join since sem_post would not wake sleeping reader threads since the sem_wait was called when the semaphore was not yet initialized.

I tested the bugfix and it works, the program no longer results in deadlock.

However, I have another issue I would like to address and expect a comment on it.

The whole multi receive thing is kind of  not welcomed in situations when you don't really want to use it, but you have more than one input interface. So currently if you have 10 input interfaces, libtrap creates 10 reader threads which are sleeping their whole life, but the user has absolutely no control whether the libtrap creates them or not. The only way to avoid it would be to create 10 separate contexts, which is not really convenient.

So I would suggest 2 options:

1. Remove the whole multi receive part from libtrap since nobody really use it. (My favorite.)
2. Implement a libtrap parameter which would create tell the libtrap to create these threads during context initialization.

Keep up the good work CESNET guys. ;-)