### PR TITLE
Unirec fixed timefromstr

### DIFF
--- a/unirec/tests/test_time.c
+++ b/unirec/tests/test_time.c
@@ -56,6 +56,8 @@ int main()
    const char *strusec = "2018-06-27T16:52:54.123456";
    const char *strnsec = "2018-06-27T16:52:54.122456789";
    const char *badstr2 = "2018-06-27T16:52:54.222222222000";
+   const char *tzstr = "2018-06-27T16:52:54Z";
+   const char *tzstr2 = "2018-06-27T16:52:54.123Z";
    const char *str = "2018-06-27T16:52:54";
 
    res = ur_time_from_string(&ut, NULL);
@@ -252,6 +254,18 @@ int main()
    }
    if (ur_time_get_nsec(ut) != 222222222) {
       fprintf(stderr, "22. Number of nanoseconds (%" PRIu32 ") is not the expected value (222222222).\n", ur_time_get_nsec(ut));
+      errors++;
+   }
+
+   // string with timezone
+   res = ur_time_from_string(&ut, tzstr);
+   if (res != 0) {
+      fprintf(stderr, "23. Parsing failed while it should succeed.\n");
+      errors++;
+   }
+   res = ur_time_from_string(&ut, tzstr2);
+   if (res != 0) {
+      fprintf(stderr, "24. Parsing failed while it should succeed.\n");
       errors++;
    }
 

--- a/unirec/unirec.c
+++ b/unirec/unirec.c
@@ -1349,7 +1349,7 @@ uint8_t ur_time_from_string(ur_time_t *ur, const char *str)
 
    res = strptime(str, "%FT%T", &t);
    /* parsed to sec - msec delimiter */
-   if ((res != NULL) && ((*res == '.') || (*res == 0))) {
+   if ((res != NULL) && ((*res == '.') || (*res == 0) || (*res == 'z') || (*res == 'Z'))) {
       sec = timegm(&t);
       if (sec != -1) {
          if (*res != 0 && *++res != 0) {
@@ -1357,11 +1357,14 @@ uint8_t ur_time_from_string(ur_time_t *ur, const char *str)
             memset(frac_buffer, '0', 9);
             frac_buffer[9] = 0;
 
-            // now "res" points to the beginning of the fractional part,
-            // which have at leat one char.
+            // now "res" points to the beginning of the fractional part or 'Z' for UTC timezone,
+            // which have at least one char.
             // Expand the number by zeros to the right to get it in ns
             // (if there are more than 9 digits, truncate the rest)
             size_t frac_len = strlen(res);
+            if (frac_len > 0 && (res[frac_len - 1] == 'z' || res[frac_len - 1] == 'Z')) {
+                frac_len--;
+            }
             if (frac_len > 9) {
                 frac_len = 9;
             }

--- a/unirec/ur_time.h
+++ b/unirec/ur_time.h
@@ -190,8 +190,12 @@ static inline uint64_t ur_timediff_ns(ur_time_t a, ur_time_t b)
  * Convert string value str into UniRec time ur.
  *
  * \param [out] ur   Target pointer to store result.
- * \param [in] str   String in the following format: 2018-06-27T16:52:54 or 2018-06-27T16:52:54.500
- * \return 0 on success, 1 is returned on parsing error (malformed format of str) and ur is set to 0, 2 on bad parameter (NULL was passed).
+ * \param [in] str   String in the following format: 2018-06-27T16:52:54 or
+ *                   2018-06-27T16:52:54.500, str may end with "Z" (2018-06-27T16:52:54Z or
+ *                   2018-06-27T16:52:54.500Z) indicating UTC timezone explicitly. UTC is
+ *                   recommended and should be used in any case.
+ * \return 0 on success, 1 is returned on parsing error (malformed format of
+ * str) and ur is set to 0, 2 on bad parameter (NULL was passed).
  */
 uint8_t ur_time_from_string(ur_time_t *ur, const char *str);
 


### PR DESCRIPTION
Previous version of ur_time_from_str() didn'ŧ parse timestamp in the RFC format including UTC timezone ('Z'). This PR add the support.

changelog: Add UTC timestamp support int ur_time_from_str().