### PR TITLE
report2idea: option to disable timestamp checks

### DIFF
--- a/pycommon/report2idea.py
+++ b/pycommon/report2idea.py
@@ -202,6 +202,10 @@ def Run(module_name, module_desc, req_type, req_format, conv_func, arg_parser = 
 
     arg_parser.add_argument('-v', '--verbose', metavar='VERBOSE_LEVEL', default=3, type=int,
             help="""Enable verbose mode (may be used by some modules, common part doesn't print anything).\nLevel 1 logs everything, level 5 only critical errors. Level 0 doesn't log.""")
+
+    arg_parser.add_argument('-D', '--dontvalidate', action='store_true', default=False,
+            help="""Disable timestamp validation, i.e. allow timestamps to be far in the past or future.""")
+
     # TRAP parameters
     trap_args = arg_parser.add_argument_group('Common TRAP parameters')
     trap_args.add_argument('-i', metavar="IFC_SPEC", help='See http://nemea.liberouter.org/trap-ifcspec/ for more information.')
@@ -318,7 +322,7 @@ def Run(module_name, module_desc, req_type, req_format, conv_func, arg_parser = 
                 idea['Node'][0]['Name'] = args.name
 
             # Sanity check of timestamps
-            if not check_valid_timestamps(idea):
+            if args.dontvalidate == False and not check_valid_timestamps(idea):
                 print("Invalid timestamps in skipped message: {0}".format(json.dumps(idea)))
                 continue
 

--- a/pycommon/test/rc_23_testreporter.py
+++ b/pycommon/test/rc_23_testreporter.py
@@ -22,7 +22,7 @@ class RCReporterTest(unittest.TestCase):
         script = d + "/test2idea.py"
         data = d + "/test_data.trapcap"
         config = d + "/rc_config/stdout.yaml"
-        output = subprocess.check_output(["python2" if sys.version_info[0] < 3 else "python3", script, "-i", "f:" + data, "-c", config], env={"PYTHONPATH": d + "/.."})
+        output = subprocess.check_output(["python2" if sys.version_info[0] < 3 else "python3", script, "-D", "-i", "f:" + data, "-c", config], env={"PYTHONPATH": d + "/.."})
         output = re.sub(idre, "", output.decode("utf-8")).split("\n")
         expect = re.sub(idre, "", EXPSTRING).split("\n")
 


### PR DESCRIPTION
@thorgrin reported an issue about reporter modules failing when historical offline data are replayed.

This PR adds an option `-D` / `--dontvalidate` to skip check_valid_timestamps().