### PR TITLE
unirec: macaddr: conversion from/to string using sscanf/snprintf

### DIFF
--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -185,8 +185,8 @@ class DataTypesMACAddrRange(unittest.TestCase):
             pytrap.UnirecMACAddr("1:0:0:FF:FF:FF"), pytrap.UnirecMACAddr("c:0:0:0:0:0"))
 
         self.assertEqual(type(bl2), pytrap.UnirecMACAddrRange, "Bad type of MAC address object.")
-        self.assertEqual(str(bl6), "1:0:0:ff:ff:ff - c:0:0:0:0:0", "String representation of UnirecMACAddrRange not equal to expected string.")
-        self.assertEqual(repr(bl6), "UnirecMACAddrRange(UnirecMACAddr('1:0:0:ff:ff:ff'), UnirecMACAddr('c:0:0:0:0:0'))", "String representation of UnirecMACAddrRange not equal to expected string.")
+        self.assertEqual(str(bl6), "01:00:00:ff:ff:ff - 0c:00:00:00:00:00", "String representation of UnirecMACAddrRange not equal to expected string.")
+        self.assertEqual(repr(bl6), "UnirecMACAddrRange(UnirecMACAddr('01:00:00:ff:ff:ff'), UnirecMACAddr('0c:00:00:00:00:00'))", "String representation of UnirecMACAddrRange not equal to expected string.")
 
         # both are True:
         self.assertTrue(mac in bl1)

--- a/unirec/macaddr.h
+++ b/unirec/macaddr.h
@@ -49,11 +49,15 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdio.h>
+#include <inttypes.h>
 #include <string.h>
-#include <netinet/ether.h>
 #include "inline.h"
 
 #define MAC_STR_LEN 18
+
+#define MAC_ADD_FORMAT_SCN "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ""
+#define MAC_ADD_FORMAT_PRI "%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ""
 
 /**
  * Structure containing MAC address bytes.
@@ -86,15 +90,14 @@ INLINE mac_addr_t mac_from_bytes(uint8_t *array)
  */
 INLINE int mac_from_str(const char *str, mac_addr_t *addr)
 {
-   struct ether_addr *tmp = ether_aton(str);
-
-   if (tmp == NULL) {
-      return 0;
+   int res = sscanf(str, MAC_ADD_FORMAT_SCN, &addr->bytes[0], &addr->bytes[1], &addr->bytes[2],
+                    &addr->bytes[3], &addr->bytes[4], &addr->bytes[5]);
+   if (res == 6) {
+      return 1;
    } else {
-      memcpy(addr->bytes, tmp->ether_addr_octet, 6);
+      memset(addr->bytes, 0, 6);
+      return 0;
    }
-
-   return 1;
 }
 
 /**
@@ -117,8 +120,11 @@ INLINE int mac_cmp(const mac_addr_t *addr1, const mac_addr_t *addr2)
  */
 INLINE void mac_to_str(const mac_addr_t *addr, char *str)
 {
-   char *tmp = ether_ntoa((const struct ether_addr *) &addr->bytes);
-   strcpy(str, tmp);
+   if (str != NULL) {
+      snprintf(str, MAC_STR_LEN, MAC_ADD_FORMAT_PRI,
+               addr->bytes[0], addr->bytes[1], addr->bytes[2],
+               addr->bytes[3], addr->bytes[4], addr->bytes[5]);
+   }
 }
 
 /**


### PR DESCRIPTION
On some platforms, ether_ntoa() outputs unexpected results
(0x112233445566) instead of MAC addr notation.
This patch standardizes convertions of MAC addr UniRec type.