### PR TITLE
BUGFIX Turris SDK doesn't know 8B atomic operations

### DIFF
--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -161,6 +161,8 @@ AC_FUNC_FORK
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([clock_gettime memset munmap select socket strchr strdup strerror dup2 mkdir])
 
+AX_ATOMIC8()
+
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  include/Makefile

--- a/libtrap/m4/ax_atomic8.m4
+++ b/libtrap/m4/ax_atomic8.m4
@@ -1,0 +1,14 @@
+AC_DEFUN([AX_ATOMIC8], [
+AC_MSG_CHECKING([Atomic operations 8B])
+AC_LANG_PUSH([C])
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
+#include <stdint.h>
+#include <inttypes.h>
+int main(int argc, char **argv) {
+	uint64_t a = 1;
+	__sync_bool_compare_and_swap_8(&a, 1, 0);
+}
+]])], [AC_DEFINE([ATOMICOPS], [1], [supported atomic operations])
+AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no])])
+AC_LANG_POP([C])
+])

--- a/libtrap/src/trap_internal.c
+++ b/libtrap/src/trap_internal.c
@@ -111,3 +111,26 @@ void trap_verbose_msg(int level, char *string)
    fflush(stderr);
    string[0] = 0;
 }
+
+#ifndef ATOMICOPS
+static pthread_mutex_t atomic_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+_Bool __sync_bool_compare_and_swap_8(int64_t *ptr, int64_t oldvar, int64_t newval)
+{
+   pthread_mutex_lock(&atomic_mutex);
+   int64_t tmp = *ptr;
+   *ptr = newval;
+   pthread_mutex_unlock(&atomic_mutex);
+   return tmp == oldvar;
+}
+
+uint64_t __sync_fetch_and_add_8(uint64_t *ptr, uint64_t value)
+{
+   pthread_mutex_lock(&atomic_mutex);
+   uint64_t tmp = *ptr;
+   *ptr += value;
+   pthread_mutex_unlock(&atomic_mutex);
+   return tmp;
+}
+#endif
+

--- a/libtrap/src/trap_internal.h
+++ b/libtrap/src/trap_internal.h
@@ -362,5 +362,12 @@ struct trap_buffer_header_s {
 } __attribute__ ((__packed__));
 typedef struct trap_buffer_header_s trap_buffer_header_t;
 
+#ifndef ATOMICOPS
+_Bool __sync_bool_compare_and_swap_8(int64_t *ptr, int64_t oldvar, int64_t newval);
+
+uint64_t __sync_fetch_and_add_8(uint64_t *ptr, uint64_t value);
+
+#endif
+
 #endif
 

--- a/unirec/macaddr.h
+++ b/unirec/macaddr.h
@@ -56,6 +56,14 @@ extern "C" {
 
 #define MAC_STR_LEN 18
 
+#ifndef PRIx8
+#define PRIx8 "x"
+#endif
+
+#ifndef SCNx8
+#define SCNx8 "hhx"
+#endif
+
 #define MAC_ADD_FORMAT_SCN "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ""
 #define MAC_ADD_FORMAT_PRI "%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ""
 


### PR DESCRIPTION
This PR contains configure check for atomic functions that are missing in Turris SDK toolchain. When there is no definition of `__sync_bool_compare_and_swap_8()`, libtrap defines its own.
Otherwise, gcc builtins are used.