### PR TITLE
libtrap: file: extend suffix to 4 digits for better ordering

### DIFF
--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -223,7 +223,7 @@ int create_next_filename(void *priv)
 
    /* If the user specified file splitting based on size */
    if (config->file_change_size != 0) {
-      int new_len = sprintf(buf, "%s.%zu", backup, config->file_index);
+      int new_len = sprintf(buf, "%s.%04zu", backup, config->file_index);
       if (new_len < 0) {
          VERBOSE(CL_ERROR, "FILE IFC[%"PRIu32"]: sprintf failed.", config->ifc_idx);
          return TRAP_E_IO_ERROR;
@@ -239,7 +239,7 @@ int create_next_filename(void *priv)
    /* If the user specified append mode, get the lowest possible numeric suffix for which there does not exist a file */
    if (config->mode[0] == 'a') {
       while (access(buf, F_OK) != -1) {
-         int new_len = sprintf(buf, "%s.%zu", backup, config->file_index);
+         int new_len = sprintf(buf, "%s.%04zu", backup, config->file_index);
          if (new_len < 0) {
             VERBOSE(CL_ERROR, "FILE IFC[%"PRIu32"]: sprintf failed.", config->ifc_idx);
             return TRAP_E_IO_ERROR;


### PR DESCRIPTION
Files with just one digit suffix are not ordered correctly by default.
That means file.10 is before file.2 (alphanumeric ordering is a default
behavior).  This patch changes suffix format to 4 digits with leading
zeros, such as file.0010, file.0002.