### PR TITLE
Pytrap bugfixes

### DIFF
--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -1443,12 +1443,13 @@ UnirecTemplate_createMessage(pytrap_unirectemplate *self, PyObject *args, PyObje
     uint32_t data_size = 0;
 
     static char *kwlist[] = {"dyn_size", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|H", kwlist, &data_size)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I", kwlist, &data_size)) {
         return NULL;
     }
     data_size += ur_rec_fixlen_size(self->urtmplt);
     if (data_size >= UR_MAX_SIZE) {
-        PyErr_SetString(TrapError, "Max size of message is 65535 bytes.");
+        PyErr_Format(TrapError, "Size of message is %d B, which is more than maximum %d bytes.",
+                     data_size, UR_MAX_SIZE);
         return NULL;
     }
     data = ur_create_record(self->urtmplt, (uint16_t) data_size);

--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -1307,8 +1307,7 @@ UnirecTemplate_getData(pytrap_unirectemplate *self)
         return NULL;
     }
 
-    Py_INCREF(self->data_obj);
-    return self->data_obj;
+    return PyByteArray_FromStringAndSize(self->data, ur_rec_size(self->urtmplt, self->data));
 }
 
 static PyObject *
@@ -1453,7 +1452,7 @@ UnirecTemplate_createMessage(pytrap_unirectemplate *self, PyObject *args, PyObje
         return NULL;
     }
     data = ur_create_record(self->urtmplt, (uint16_t) data_size);
-    PyObject *res = PyByteArray_FromStringAndSize(data, (uint16_t) data_size);
+    PyObject *res = PyByteArray_FromStringAndSize(data, data_size);
 
     if (self->data != NULL) {
         /* decrease refCount of the previously stored data */

--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -1447,7 +1447,7 @@ UnirecTemplate_createMessage(pytrap_unirectemplate *self, PyObject *args, PyObje
         return NULL;
     }
     data_size += ur_rec_fixlen_size(self->urtmplt);
-    if (data_size >= UR_MAX_SIZE) {
+    if (data_size > UR_MAX_SIZE) {
         PyErr_Format(TrapError, "Size of message is %d B, which is more than maximum %d bytes.",
                      data_size, UR_MAX_SIZE);
         return NULL;

--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -782,3 +782,10 @@ class CopyTemplateTest(unittest.TestCase):
         self.assertEqual(astr, bstr)
         self.assertEqual(astr, '(ipaddr SRC_IP,time TIME_FIRST,uint32 ABC,uint32 BCD,bytes STREAMBYTES,string TEXT)')
 
+class AllocateBigMessage(unittest.TestCase):
+    def runTest(self):
+        import pytrap
+        a = pytrap.UnirecTemplate("ipaddr SRC_IP,time TIME_FIRST,uint32 ABC,uint32 BCD,string TEXT,bytes STREAMBYTES")
+        with self.assertRaises(pytrap.TrapError):
+            a.createMessage(100000)
+

--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -448,7 +448,9 @@ class DataAccessSetTest(unittest.TestCase):
         a = pytrap.UnirecTemplate("ipaddr SRC_IP,time TIME_FIRST,uint32 ABC,uint32 BCD,string TEXT,bytes STREAMBYTES")
         data = a.createMessage(100)
         for i in range(100):
-            self.assertEqual(data, a.getData())
+            getdata = a.getData()
+            # size of created (allocated) message and retrieved message differs (due to non-filled variable fields)
+            self.assertEqual(data[:len(getdata)], getdata)
 
         a.ABC = 666
         self.assertEqual(a.ABC, 666)


### PR DESCRIPTION
Pytrap UnirecTemplate.getData() now returns only memory that was set (instead of the whole allocated memory).  This saves resources when the data are sent via output IFC.

Additionally, check for argument of createMessage() was insufficient. The argument was changed to int in PyArg_ParseTupleAndKeywords() so the comparison with max size of UniRec message can work.