### PR TITLE
libtrap - bugfix in test_echo_reply

### DIFF
--- a/libtrap/tests/test_echo_reply.c
+++ b/libtrap/tests/test_echo_reply.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
             last_size = read_size;
          }
          last_value = (*cur_value);
-      } else if (ret == TRAP_E_TERMINATED) {
+      } else {
          stop = 1;
       }
       iteration++;

--- a/libtrap/tests/test_tls.sh
+++ b/libtrap/tests/test_tls.sh
@@ -45,8 +45,8 @@ PROG_ECHO_REPLY="test_echo_reply"
 test -z "$srcdir" && export srcdir=.
 
 #kill leftover tests
-pkill $PROG_ECHO &> /dev/null && sleep 1
-pkill $PROG_ECHO_REPLY &> /dev/null && sleep 1
+pkill "^$PROG_ECHO" &> /dev/null && sleep 1
+pkill "^$PROG_ECHO_REPLY" &> /dev/null && sleep 1
 
 INTERFACE_SENDER="T:12345:${srcdir}/tls-certificates/server.key:${srcdir}/tls-certificates/server.crt:${srcdir}/tls-certificates/ca.crt"
 INTERFACE_RECEIVER="T:12345:${srcdir}/tls-certificates/unver.key:${srcdir}/tls-certificates/unver.crt:${srcdir}/tls-certificates/ca.crt"

--- a/libtrap/tests/test_tls.sh
+++ b/libtrap/tests/test_tls.sh
@@ -45,8 +45,8 @@ PROG_ECHO_REPLY="test_echo_reply"
 test -z "$srcdir" && export srcdir=.
 
 #kill leftover tests
-kill -2 `pgrep $PROG_ECHO` &> /dev/null && sleep 1
-kill -2 `pgrep $PROG_ECHO_REPLY` &> /dev/null && sleep 1
+pkill $PROG_ECHO &> /dev/null && sleep 1
+pkill $PROG_ECHO_REPLY &> /dev/null && sleep 1
 
 INTERFACE_SENDER="T:12345:${srcdir}/tls-certificates/server.key:${srcdir}/tls-certificates/server.crt:${srcdir}/tls-certificates/ca.crt"
 INTERFACE_RECEIVER="T:12345:${srcdir}/tls-certificates/unver.key:${srcdir}/tls-certificates/unver.crt:${srcdir}/tls-certificates/ca.crt"

--- a/libtrap/tests/test_tls.sh
+++ b/libtrap/tests/test_tls.sh
@@ -44,9 +44,9 @@ PROG_ECHO_REPLY="test_echo_reply"
 
 test -z "$srcdir" && export srcdir=.
 
-#checking if some leftover tests are running
-pgrep "^$PROG_ECHO_REPLY$" > /dev/null && { echo "Existing process..."; exit 1; }
-pgrep "^$PROG_ECHO$" > /dev/null && { echo "Existing process..."; exit 1; }
+#kill leftover tests
+kill -2 `pgrep $PROG_ECHO` &> /dev/null && sleep 1
+kill -2 `pgrep $PROG_ECHO_REPLY` &> /dev/null && sleep 1
 
 INTERFACE_SENDER="T:12345:${srcdir}/tls-certificates/server.key:${srcdir}/tls-certificates/server.crt:${srcdir}/tls-certificates/ca.crt"
 INTERFACE_RECEIVER="T:12345:${srcdir}/tls-certificates/unver.key:${srcdir}/tls-certificates/unver.crt:${srcdir}/tls-certificates/ca.crt"


### PR DESCRIPTION
trap_recv() may return other codes than 'terminated' that signify failure (e.g. unsuccessful certificate verification results in 'bad params').