### PR TITLE
libtrap: fix cpu usage

### DIFF
--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1304,6 +1304,7 @@ static void *sending_thread_func(void *priv)
             pthread_cond_wait(&c->cond_no_data, &c->mtx_no_data);
          }
          pthread_mutex_unlock(&c->mtx_no_data);
+         continue;
       }
 
       res = select(maxsd + 1, &disset, &set, NULL, &select_timeout);

--- a/libtrap/src/ifc_tcpip_internal.h
+++ b/libtrap/src/ifc_tcpip_internal.h
@@ -103,8 +103,9 @@ typedef struct tcpip_sender_private_s {
    pthread_t accept_thr;                   /**< Pthread structure containing info about accept thread */
    pthread_t send_thr;                     /**< Pthread structure containing info about sending thread */
 
-   pthread_mutex_t dummy_mtx;              /**< Dummy mutex used in pthread_cond_timedwait() */
-   pthread_cond_t cond;                    /**< Condition struct for pthread_cond_timedwait() */
+   pthread_mutex_t mtx_no_data;            /**< Mutex for cond_no_data */
+   pthread_cond_t cond_no_data;            /**< Condition struct used when waiting for new data */
+   pthread_cond_t cond_full_buffer;        /**< Condition struct used when waiting for free buffer */
 } tcpip_sender_private_t;
 
 /**

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1143,7 +1143,7 @@ static inline void disconnect_client(tls_sender_private_t *priv, int cl_id)
    for (i = 0; i < priv->buffer_count; ++i) {
       del_index(&priv->buffers[i].clients_bit_arr, cl_id);
       if (priv->buffers[i].clients_bit_arr == 0) {
-         pthread_cond_broadcast(&priv->cond);
+         pthread_cond_broadcast(&priv->cond_full_buffer);
       }
    }
    del_index(&priv->clients_bit_arr, cl_id);
@@ -1332,14 +1332,21 @@ refuse_client:
  */
 static inline void finish_buffer(tls_sender_private_t *priv, buffer_t *buffer)
 {
-   uint32_t header = htonl(buffer->wr_index);
-   memcpy(buffer->header, &header, sizeof(header));
-
-   priv->active_buffer = (priv->active_buffer + 1) % priv->buffer_count;
    priv->autoflush_timestamp = get_cur_timestamp();
 
-   buffer->clients_bit_arr = priv->clients_bit_arr;
-   buffer->wr_index = 0;
+   if (buffer->clients_bit_arr == 0 && buffer->wr_index != 0) {
+      uint32_t header = htonl(buffer->wr_index);
+      memcpy(buffer->header, &header, sizeof(header));
+
+      priv->active_buffer = (priv->active_buffer + 1) % priv->buffer_count;
+
+      buffer->clients_bit_arr = priv->clients_bit_arr;
+      buffer->wr_index = 0;
+   }
+
+   pthread_mutex_lock(&priv->mtx_no_data);
+   pthread_cond_broadcast(&priv->cond_no_data);
+   pthread_mutex_unlock(&priv->mtx_no_data);
 }
 
 /**
@@ -1408,7 +1415,7 @@ again:
          del_index(&buffer->clients_bit_arr, cl_id);
          if (buffer->clients_bit_arr == 0) {
             __sync_add_and_fetch(&priv->ctx->counter_send_buffer[priv->ifc_idx], 1);
-            pthread_cond_broadcast(&priv->cond);
+            pthread_cond_broadcast(&priv->cond_full_buffer);
          }
 
          /* Assign client the next buffer in sequence */
@@ -1434,7 +1441,8 @@ static void *sending_thread_func(void *priv)
    uint8_t buffer[DEFAULT_MAX_DATA_LENGTH];
    uint64_t send_entry_time;
    uint64_t send_exit_time;
-   uint8_t client_ready;
+   uint8_t waiting_clients;
+   struct timeval select_timeout;
 
    tls_sender_private_t *c = (tls_sender_private_t *) priv;
 
@@ -1453,7 +1461,9 @@ static void *sending_thread_func(void *priv)
 
       FD_ZERO(&disset);
       FD_ZERO(&set);
-      client_ready = 0;
+      waiting_clients = 0;
+      select_timeout.tv_sec = 1;
+      select_timeout.tv_usec = 0;
 
       /* Add term_pipe for reading into the disconnect client set */
       FD_SET(c->term_pipe[0], &disset);
@@ -1482,6 +1492,7 @@ static void *sending_thread_func(void *priv)
          }
 
          if (check_index(assigned_buffer->clients_bit_arr, i) == 0) {
+            ++waiting_clients;
             continue;
          }
 
@@ -1491,15 +1502,18 @@ static void *sending_thread_func(void *priv)
          }
 
          FD_SET(cl->sd, &set);
-         ++client_ready;
       }
 
-      if (client_ready == 0) {
-         /* No client will be receiving, do not call select */
+      if (waiting_clients == c->connected_clients) {
+         pthread_mutex_lock(&c->mtx_no_data);
+         pthread_cond_wait(&c->cond_no_data, &c->mtx_no_data);
+         pthread_mutex_unlock(&c->mtx_no_data);
          continue;
       }
 
-      if (select(maxsd + 1, &disset, &set, NULL, NULL) < 0) {
+      res = select(maxsd + 1, &disset, &set, NULL, &select_timeout);
+      if (res < 0) {
+         /* Select returned with an error */
          if (c->is_terminated == 0) {
             switch (errno) {
                case EINTR:
@@ -1512,6 +1526,9 @@ static void *sending_thread_func(void *priv)
             VERBOSE(CL_VERBOSE_ADVANCED, "Sending thread: terminating...");
             pthread_exit(NULL);
          }
+      } else if (res == 0) {
+         /* Select timed out - no client will be receiving */
+         continue;
       }
 
       if (FD_ISSET(c->term_pipe[0], &disset)) {
@@ -1614,9 +1631,7 @@ repeat:
       ts.tv_nsec %= 1000000000L;
 
       /* Wait until woken up by sending thread or until timeout elapses */
-      pthread_mutex_lock(&c->dummy_mtx);
-      res = pthread_cond_timedwait(&c->cond, &c->dummy_mtx, &ts);
-      pthread_mutex_unlock(&c->dummy_mtx);
+      res = pthread_cond_timedwait(&c->cond_full_buffer, &c->ctx->out_ifc_list[c->ifc_idx].ifc_mtx, &ts);
       switch (res) {
          case 0:
             /* Succesfully locked, buffer can be used */
@@ -1740,8 +1755,9 @@ void tls_sender_destroy(void *priv)
          free(c->buffers);
       }
 
-      pthread_mutex_destroy(&c->dummy_mtx);
-      pthread_cond_destroy(&c->cond);
+      pthread_mutex_destroy(&c->mtx_no_data);
+      pthread_cond_destroy(&c->cond_no_data);
+      pthread_cond_destroy(&c->cond_full_buffer);
       free(c);
    }
 }
@@ -1989,8 +2005,9 @@ int create_tls_sender_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_
    priv->active_buffer = 0;
    priv->autoflush_timestamp = get_cur_timestamp();
 
-   pthread_mutex_init(&priv->dummy_mtx, NULL);
-   pthread_cond_init(&priv->cond, NULL);
+   pthread_mutex_init(&priv->mtx_no_data, NULL);
+   pthread_cond_init(&priv->cond_no_data, NULL);
+   pthread_cond_init(&priv->cond_full_buffer, NULL);
 
    VERBOSE(CL_VERBOSE_ADVANCED, "config:\nserver_port:\t%s\nmax_clients:\t%u\nbuffer count:\t%u\nbuffer size:\t%uB\n",
                                 priv->server_port, priv->clients_arr_size,priv->buffer_count, priv->buffer_size);
@@ -2051,8 +2068,9 @@ failsafe_cleanup:
       if (priv->clients != NULL) {
          X(priv->clients);
       }
-      pthread_mutex_destroy(&priv->dummy_mtx);
-      pthread_cond_destroy(&priv->cond);
+      pthread_mutex_destroy(&priv->mtx_no_data);
+      pthread_cond_destroy(&priv->cond_no_data);
+      pthread_cond_destroy(&priv->cond_full_buffer);
       X(priv);
    }
 #undef X

--- a/libtrap/src/ifc_tls_internal.h
+++ b/libtrap/src/ifc_tls_internal.h
@@ -114,8 +114,9 @@ typedef struct tls_sender_private_s {
     pthread_t accept_thr;                   /**< Pthread structure containing info about accept thread */
     pthread_t send_thr;                     /**< Pthread structure containing info about sending thread */
 
-    pthread_mutex_t dummy_mtx;              /**< Dummy mutex used in pthread_cond_timedwait() */
-    pthread_cond_t cond;                    /**< Condition struct for pthread_cond_timedwait() */
+    pthread_mutex_t mtx_no_data;            /**< Mutex for cond_no_data */
+    pthread_cond_t cond_no_data;            /**< Condition struct used when waiting for new data */
+    pthread_cond_t cond_full_buffer;        /**< Condition struct used when waiting for free buffer */
 } tls_sender_private_t;
 
 /**

--- a/libtrap/src/trap_internal.h
+++ b/libtrap/src/trap_internal.h
@@ -328,6 +328,18 @@ struct trap_ctx_priv_s {
     */
    uint64_t *counter_recv_buffer;
    /**
+    * counter_recv_delay_last represents time interval between last two recv() calls (in microseconds).
+    */
+   uint64_t *counter_recv_delay_last;
+   /**
+    * counter_recv_delay_total represents total time spent outside of recv() function (in microseconds).
+    */
+   uint64_t *counter_recv_delay_total;
+   /**
+    * recv_delay_timestamp is used to determine the time that has elapsed between last two recv() calls
+    */
+   uint64_t *recv_delay_timestamp;
+   /**
     * @}
     */
 };

--- a/libtrap/tools/trap_stats.c
+++ b/libtrap/tools/trap_stats.c
@@ -108,7 +108,7 @@ int decode_cnts_from_json(char **data)
 
    uint64_t ifc_cnts[4];
    memset(ifc_cnts, 0, 4 * sizeof(uint64_t));
-   uint8_t msg_idx = 0, buffers_idx = 1, dropped_msg_idx = 2, af_idx = 3;
+   uint8_t msg_idx = 0, buffers_idx = 1, dropped_msg_idx = 2, af_idx = 3, delay_last_idx = 2, delay_total_idx = 3;
 
    json_error_t error;
    json_t *json_struct = NULL;
@@ -225,8 +225,24 @@ int decode_cnts_from_json(char **data)
       }
       ifc_state = (uint8_t)(json_integer_value(cnt));
 
-      printf("\tID: %s, TYPE: %c, IS_CONN: %d, RM: %" PRIu64 ", RB: %" PRIu64 "\n", ifc_id, ifc_type, ifc_state, ifc_cnts[msg_idx], ifc_cnts[buffers_idx]);
-      memset(ifc_cnts, 0, 2 * sizeof(uint64_t));
+      cnt = json_object_get(in_ifc_cnts, "delay_last");
+      if (cnt == NULL) {
+         printf("[ERROR] Could not get key \"%s\" from an input interface json object.\n", "delay_last");
+         json_decref(json_struct);
+         return -1;
+      }
+      ifc_cnts[delay_last_idx] = json_integer_value(cnt);
+
+      cnt = json_object_get(in_ifc_cnts, "delay_total");
+      if (cnt == NULL) {
+         printf("[ERROR] Could not get key \"%s\" from an input interface json object.\n", "delay_total");
+         json_decref(json_struct);
+         return -1;
+      }
+      ifc_cnts[delay_total_idx] = json_integer_value(cnt);
+
+      printf("\tID: %s, TYPE: %c, IS_CONN: %d, RM: %" PRIu64 ", RB: %" PRIu64 ", DELAY_LAST [us]: %" PRIu64 ", DELAY_TOTAL [s]: %" PRIu64 "\n", ifc_id, ifc_type, ifc_state, ifc_cnts[msg_idx], ifc_cnts[buffers_idx], ifc_cnts[delay_last_idx], ifc_cnts[delay_total_idx]);
+      memset(ifc_cnts, 0, 4 * sizeof(uint64_t));
    }
 
 


### PR DESCRIPTION
Fix unintentional busy waiting in TCP/IP and TLS interfaces resulting in high CPU usage.

Add "delay" counters to input interfaces for measuring of time intervals between receive calls (may be useful for debugging slow modules).