### PR TITLE
libtrap: add missing atomic_ops for turris

### DIFF
--- a/libtrap/src/trap_internal.c
+++ b/libtrap/src/trap_internal.c
@@ -132,5 +132,33 @@ uint64_t __sync_fetch_and_add_8(uint64_t *ptr, uint64_t value)
    pthread_mutex_unlock(&atomic_mutex);
    return tmp;
 }
+
+uint64_t __sync_add_and_fetch_8(uint64_t *ptr, uint64_t value)
+{
+   pthread_mutex_lock(&atomic_mutex);
+   uint64_t tmp = *ptr;
+   *ptr += value;
+   pthread_mutex_unlock(&atomic_mutex);
+   return tmp;
+}
+
+uint64_t __sync_and_and_fetch_8(uint64_t *ptr, uint64_t value);
+{
+   pthread_mutex_lock(&atomic_mutex);
+   uint64_t tmp = *ptr;
+   *ptr &= value;
+   pthread_mutex_unlock(&atomic_mutex);
+   return tmp;
+}
+
+uint64_t __sync_or_and_fetch_8(uint64_t *ptr, uint64_t value);
+{
+   pthread_mutex_lock(&atomic_mutex);
+   uint64_t tmp = *ptr;
+   *ptr |= value;
+   pthread_mutex_unlock(&atomic_mutex);
+   return tmp;
+}
+
 #endif
 

--- a/libtrap/src/trap_internal.h
+++ b/libtrap/src/trap_internal.h
@@ -369,6 +369,12 @@ _Bool __sync_bool_compare_and_swap_8(int64_t *ptr, int64_t oldvar, int64_t newva
 
 uint64_t __sync_fetch_and_add_8(uint64_t *ptr, uint64_t value);
 
+uint64_t __sync_add_and_fetch_8(uint64_t *ptr, uint64_t value);
+
+uint64_t __sync_or_and_fetch_8(uint64_t *ptr, uint64_t value);
+
+uint64_t __sync_and_and_fetch_8(uint64_t *ptr, uint64_t value);
+
 #endif
 
 #endif


### PR DESCRIPTION
Test build using Turris SDK revealed some missing atomic functions.
This patch defines:
```
uint64_t __sync_add_and_fetch_8(uint64_t *ptr, uint64_t value);
uint64_t __sync_or_and_fetch_8(uint64_t *ptr, uint64_t value);
uint64_t __sync_and_and_fetch_8(uint64_t *ptr, uint64_t value);
```
when configure script detects missing atomops, e.g., for turris.