### PR TITLE
build: gcc10+ compatibility: add -fcommon if gcc version is at least 10

### DIFF
--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -46,6 +46,19 @@ AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AM_CONDITIONAL([GCC], [test x$GCC = xyes])
 
+# Check the version of the compiler, if gcc is used and it is newer than 10, we
+# need -fcommon in CFLAGS
+if test x"$CC" = xgcc; then
+    AC_MSG_CHECKING([for version of compiler])
+    compiler_version="`$CC -dumpversion`"
+    if test "$compiler_version" -ge 10 2>/dev/null ; then
+        CFLAGS="$CFLAGS -fcommon"
+	AC_MSG_RESULT([$compiler_version -> adding -fcommon into CFLAGS])
+    else
+	AC_MSG_RESULT([$compiler_version])
+    fi
+fi
+
 # Check for rpmbuild
 AC_CHECK_PROG(RPMBUILD, rpmbuild, rpmbuild, [""])
 AC_CHECK_PROG(DEBUILD, debuild, debuild, [""])


### PR DESCRIPTION
According to https://gcc.gnu.org/gcc-10/changes.html, new gcc has changed
default behavior so we get compile errors without -fno-common.