### PR TITLE
Libtrap blocked module fix

### DIFF
--- a/libtrap/README.ifcspec.md
+++ b/libtrap/README.ifcspec.md
@@ -118,7 +118,7 @@ Output interface:
 Name of file (path to the file) must be specified.
 
 Mode is optional. There are two types of mode: `a` - append, `w` - write (default).
-If the specified file exists, mode write overwrites it, mode append creates a new file with an integer suffix, e.g. `data.trapcap.0` (or `data.trapcap.1` if the former exists, and so on, it simply finds the first unused number).
+If the specified file exists, mode write overwrites it, mode append creates a new file with an integer suffix, e.g. `data.trapcap.00000` (or `data.trapcap.00001` if the former exists, and so on, it simply finds the first unused number).
 
 If parameter `time=` is set, the output interface will split captured data to individual files as often, as value of this parameter indicates.
 Output interface assumes the value of parameter `time=` is in minutes.
@@ -127,29 +127,29 @@ Parameter `time=` is optional and is not set by default.
 
 If parameter `size=` is set, the output interface will split captured data to individual files after size of current file exceeds given threshold.
 Output interface assumes the value of parameter `size=` is in MB.
-If parameter `size=` is set, numeric suffix as added to original file name for each file in ascending order starting with 0.
+If parameter `size=` is set, numeric suffix as added to original file name for each file in ascending order starting with 00000.
 Parameter `size=` is optional and is not set by default.
 
-If both `time=` and `size=` are specified, the data are split primarily by time, and only if a file of one time interval exceeds the size limit, it is further splitted. The index of size-splitted file is appended after the time, e.g. `data.trapcap.201604181000.0`.
+If both `time=` and `size=` are specified, the data are split primarily by time, and only if a file of one time interval exceeds the size limit, it is further splitted. The index of size-splitted file is appended after the time, e.g. `data.trapcap.201604181000.00000`.
 
 Example:
 ```
 -i "f:~/nemea/data.trapcap:w"                  // stores all captured data to one file (overwrites current file if it exists)
 -i "f:~/nemea/data.trapcap:w:time=30"          // creates individual files each 30 minutes, e.g. "data.trapcap.201604180930", "data.trapcap.201604181000" etc.
--i "f:~/nemea/data.trapcap:w:size=100"         // creates file "data.trapcap" and when its size reaches 100 MB, a new file named "data.trapcap.0", then "data.trapcap.1" etc.
--i "f:~/nemea/data.trapcap:w:time=30:size=100" // creates set of files "data.trapcap.201604180930", "data.trapcap.201604180930.0" etc. and after 30 minutes, "data.trapcap.201604181000"
+-i "f:~/nemea/data.trapcap:w:size=100"         // creates file "data.trapcap" and when its size reaches 100 MB, a new file named "data.trapcap.00000", then "data.trapcap.00001" etc.
+-i "f:~/nemea/data.trapcap:w:time=30:size=100" // creates set of files "data.trapcap.201604180930", "data.trapcap.201604180930.00000" etc. and after 30 minutes, "data.trapcap.201604181000"
 ```
 Output file interface and negotiation:
 Whenever new format of data is created, output interface creates new file with numeric suffix.
-Example: `-i "f:~/nemea/data.trapcap:w"` following sequence of files will be created if data format changes: data.trapcap, data.trapcap.0, data.trapcap.1 etc.
+Example: `-i "f:~/nemea/data.trapcap:w"` following sequence of files will be created if data format changes: data.trapcap, data.trapcap.00000, data.trapcap.00001 etc.
 
 When mode `a` is specified, the interface finds first non-existing file in which it writes data.
 Example: 
-Assume we have already files "data.trapcap" and "data.trapcap.0", the following command:
+Assume we have already files "data.trapcap" and "data.trapcap.00000", the following command:
 ```
 -i "f:~/nemea/data.trapcap:a"
 ```
-checks for existing files and first captured data will be stored to file "data.trapcap.1".
+checks for existing files and first captured data will be stored to file "data.trapcap.00001".
 
 Output file interface can also write data to /dev/stdout and /dev/null, however mode `w` must be specified.
 

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -230,6 +230,7 @@ int create_next_filename(file_private_t *config)
          }
 
          memcpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
+         buf[len + FILE_SIZE_SUFFIX_LEN] = 0;
          config->file_index++;
 
          /* Detected overflow */
@@ -255,6 +256,7 @@ int create_next_filename(file_private_t *config)
 
       memcpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
       len += FILE_SIZE_SUFFIX_LEN;
+      buf[len] = 0;
       config->file_index++;
    }
 

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -229,7 +229,7 @@ int create_next_filename(file_private_t *config)
             return TRAP_E_IO_ERROR;
          }
 
-         strncpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
+         memcpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
          config->file_index++;
 
          /* Detected overflow */
@@ -253,7 +253,7 @@ int create_next_filename(file_private_t *config)
          return TRAP_E_IO_ERROR;
       }
 
-      strncpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
+      memcpy(buf + len, suffix, FILE_SIZE_SUFFIX_LEN);
       len += FILE_SIZE_SUFFIX_LEN;
       config->file_index++;
    }
@@ -375,7 +375,7 @@ neg_start:
             return TRAP_E_OK;
          }
 
-         strncpy(config->filename, config->files[config->file_index], strlen(config->files[config->file_index]) + 1);
+         strncpy(config->filename, config->files[config->file_index], sizeof(config->filename) - 1);
          if (switch_file(config) == TRAP_E_OK) {
 #ifdef ENABLE_NEGOTIATION
             goto neg_start;
@@ -825,7 +825,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    }
 
    free(dest);
-   strncpy(priv->filename_tmplt, exp_result.we_wordv[0], sizeof(priv->filename_tmplt));
+   strncpy(priv->filename_tmplt, exp_result.we_wordv[0], sizeof(priv->filename_tmplt) - 1);
    wordfree(&exp_result);
 
    /* Parse mode */

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -802,12 +802,14 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    if (length) {
       dest = (char*) calloc(length + 1, sizeof(char));
       if (!dest) {
+         free(priv->buffer.header);
          free(priv);
          return trap_error(ctx, TRAP_E_MEMORY);
       }
 
       strncpy(dest, params, length);
    } else {
+      free(priv->buffer.header);
       free(priv);
       return trap_errorf(ctx, TRAP_E_BADPARAMS, "FILE OUTPUT IFC[%"PRIu32"]: Filename not specified.", idx);
    }
@@ -815,6 +817,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    /* Perform shell-like expansion of ~ */
    if (wordexp(dest, &exp_result, 0) != 0) {
       VERBOSE(CL_ERROR, "FILE OUTPUT IFC[%"PRIu32"]: Unable to perform shell-like expansion of: %s", idx, dest);
+      free(priv->buffer.header);
       free(priv);
       free(dest);
       wordfree(&exp_result);
@@ -853,6 +856,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
          if (length > TIME_PARAM_LEN && strncmp(params_next, TIME_PARAM, TIME_PARAM_LEN) == 0) {
             priv->file_change_time = atoi(params_next + TIME_PARAM_LEN);
             if (strlen(priv->filename_tmplt) + TIME_FORMAT_STRING_LEN > sizeof(priv->filename_tmplt) - 1) {
+               free(priv->buffer.header);
                free(priv);
                return trap_errorf(ctx, TRAP_E_BADPARAMS, "FILE OUTPUT IFC[%"PRIu32"]: Path and filename exceeds maximum size: %u.", idx, sizeof(priv->filename_tmplt) - 1);
             }
@@ -874,6 +878,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    /* Create first filename from the prepared template */
    int status = create_next_filename(priv);
    if (status != TRAP_E_OK) {
+      free(priv->buffer.header);
       free(priv);
       return trap_errorf(ctx, status, "FILE OUTPUT IFC[%"PRIu32"]: Error during output file creation.", idx);
    }
@@ -881,6 +886,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    /* Open first file */
    status = switch_file(priv);
    if (status != TRAP_E_OK) {
+      free(priv->buffer.header);
       free(priv);
       return trap_errorf(ctx, status, "FILE OUTPUT IFC[%"PRIu32"]: Error during output file opening.", idx);
    }

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -828,22 +828,6 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
    strncpy(priv->filename_tmplt, exp_result.we_wordv[0], sizeof(priv->filename_tmplt) - 1);
    wordfree(&exp_result);
 
-   /* Parse mode */
-   if (params_next) {
-      length = strcspn(params_next, ":");
-      if (length == 1) {
-         if (params_next[0] == 'a') {
-            priv->mode[0] = 'a';
-         }
-
-         if (params_next[1] == ':') {
-            params_next = params_next + 2;
-         } else {
-            params_next = NULL;
-         }
-      }
-   }
-
    /* Set special behavior for /dev/stdout */
    if (strncmp(priv->filename_tmplt, "/dev/stdout", 11) == 0) {
       priv->mode[0] = 'w';
@@ -865,6 +849,8 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
             strcat(priv->filename_tmplt, TIME_FORMAT_STRING);
          } else if (length > SIZE_PARAM_LEN && strncmp(params_next, SIZE_PARAM, SIZE_PARAM_LEN) == 0) {
             priv->file_change_size = atoi(params_next + SIZE_PARAM_LEN);
+         } else if (length == 1 && params_next[0] == 'a') {
+            priv->mode[0] = 'a';
          }
 
          if (params_next[length] == '\0') {

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1319,6 +1319,21 @@ static void *sending_thread_func(void *priv)
          }
       } else if (res == 0) {
          /* Select timed out - no client will be receiving */
+         for (i = 0; i < c->clients_arr_size; ++i) {
+            if (check_index(c->clients_bit_arr, i) == 0) {
+               continue;
+            }
+
+            cl = &(c->clients[i]);
+            assigned_buffer = &c->buffers[cl->assigned_buffer];
+            if (check_index(assigned_buffer->clients_bit_arr, i) == 0) {
+               continue;
+            }
+
+            /* Disconnect clients that are unable to receive data fast enough and are blocking the whole module. */
+            disconnect_client(c, i);
+            VERBOSE(CL_VERBOSE_ADVANCED, "Sending thread: Client %" PRIu32 " could not receive data fast enough and was disconnected", i);
+         }
          continue;
       }
 

--- a/libtrap/src/third-party/libjansson/error.c
+++ b/libtrap/src/third-party/libjansson/error.c
@@ -25,7 +25,7 @@ void jsonp_error_set_source(json_error_t *error, const char *source)
 
     length = strlen(source);
     if(length < JSON_ERROR_SOURCE_LENGTH)
-        strncpy(error->source, source, length + 1);
+        strncpy(error->source, source, sizeof(error->source));
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
         strncpy(error->source, "...", 4);


### PR DESCRIPTION
Fixed bug where one slow reading / idle client could block the entire module. This could happen with `WAIT`, `HALF_WAIT` or `NO_WAIT` timeouts.

Bug scenario:
```
flow source -> traffic_repeater -> flow_counter1
            -> flow_counter2
```
When we stop the `flow_counter1` module and `traffic_repeater` is still running, `flow_counter2` would not be able to receive any data from `flow source`.