### PR TITLE
libtrap bugfixes

### DIFF
--- a/libtrap/include/libtrap/trap.h
+++ b/libtrap/include/libtrap/trap.h
@@ -99,6 +99,7 @@ extern char *trap_default_socket_path_format;
 #define TRAP_E_FIELDS_SUBSET 22 ///< Returned when receivers fields are subset of senders fields and both sets are not identical
 #define TRAP_E_FORMAT_CHANGED 23 ///< Returned by trap_recv when format or format spec of the receivers interface has been changed
 #define TRAP_E_FORMAT_MISMATCH 24 ///< Returned by trap_recv when data format or data specifier of the output and input interfaces doesn't match
+#define TRAP_E_NEGOTIATION_FAILED 25 ///< Returned by trap_recv when negotiation of the output and input interfaces failed
 #define TRAP_E_NOT_INITIALIZED 254 ///< TRAP library not initilized
 #define TRAP_E_MEMORY 255 ///< Memory allocation error
 /**@}*/
@@ -972,6 +973,9 @@ void trap_ctx_create_ifc_dump(trap_ctx_t *ctx, const char *path);
       } else if (ret_code == TRAP_E_FORMAT_MISMATCH) { \
          fprintf(stderr, "trap_recv() error: output and input interfaces data formats or data specifiers mismatch.\n"); \
          error_cmd; \
+      } else if (ret_code == TRAP_E_NEGOTIATION_FAILED) { \
+         fprintf(stderr, "trap_recv() error: interface negotiation failed (caused by invalid reply from a remote module, corrupted file or an unknown error).\n"); \
+         error_cmd; \
       } else {\
          fprintf(stderr, "Error: trap_recv() returned %i (%s)\n", (ret_code), trap_last_error_msg);\
          error_cmd;\
@@ -995,6 +999,9 @@ void trap_ctx_create_ifc_dump(trap_ctx_t *ctx, const char *path);
          /* (module can perform some special operations with templates after trap_recv() signals format change) */ \
       } else if (ret_code == TRAP_E_FORMAT_MISMATCH) { \
          fprintf(stderr, "trap_recv() error: output and input interfaces data formats or data specifiers mismatch.\n"); \
+         error_cmd; \
+      } else if (ret_code == TRAP_E_NEGOTIATION_FAILED) { \
+         fprintf(stderr, "trap_recv() error: interface negotiation failed (caused by invalid reply from a remote module, corrupted file or an unknown error).\n"); \
          error_cmd; \
       } else {\
          fprintf(stderr, "Error: trap_recv() returned %i (%s)\n", (ret_code), trap_last_error_msg);\

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -328,7 +328,7 @@ neg_start:
       switch(input_ifc_negotiation((void *) config, TRAP_IFC_TYPE_FILE)) {
       case NEG_RES_FMT_UNKNOWN:
          VERBOSE(CL_VERBOSE_LIBRARY, "FILE INPUT IFC[%"PRIu32"] negotiation result: failed (unknown data format of the output interface).", config->ifc_idx);
-         return TRAP_E_FORMAT_MISMATCH;
+         return TRAP_E_NEGOTIATION_FAILED;
 
       case NEG_RES_CONT:
          VERBOSE(CL_VERBOSE_LIBRARY, "FILE INPUT IFC[%"PRIu32"] negotiation result: success.", config->ifc_idx);
@@ -347,7 +347,7 @@ neg_start:
 
       case NEG_RES_FAILED:
          VERBOSE(CL_VERBOSE_LIBRARY, "FILE INPUT IFC[%"PRIu32"] negotiation result: failed (error while receiving hello message from output interface).", config->ifc_idx);
-         return TRAP_E_FORMAT_MISMATCH;
+         return TRAP_E_NEGOTIATION_FAILED;
 
       case NEG_RES_FMT_MISMATCH:
          VERBOSE(CL_VERBOSE_LIBRARY, "FILE INPUT IFC[%"PRIu32"] negotiation result: failed (data format or data specifier mismatch).", config->ifc_idx);

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -420,6 +420,9 @@ conn_wait:
          if (retval == TRAP_E_FIELDS_MISMATCH) {
             config->connected = 1;
             return TRAP_E_FORMAT_MISMATCH;
+         } else if (retval == TRAP_E_NEGOTIATION_FAILED) {
+            config->connected = 1;
+            return TRAP_E_NEGOTIATION_FAILED;
          } else if (retval == TRAP_E_OK) {
             config->connected = 1;
             /* ok, wait for header as we planned */
@@ -909,7 +912,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
 
    /** Input interface negotiation */
 #ifdef ENABLE_NEGOTIATION
-   switch(input_ifc_negotiation(priv, TRAP_IFC_TYPE_TCPIP)) {
+   switch (input_ifc_negotiation(priv, TRAP_IFC_TYPE_TCPIP)) {
    case NEG_RES_FMT_UNKNOWN:
       VERBOSE(CL_VERBOSE_LIBRARY, "Input_ifc_negotiation result: failed (unknown data format of the output interface).");
       close(sockfd);
@@ -933,7 +936,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
 
    case NEG_RES_FAILED:
       VERBOSE(CL_VERBOSE_LIBRARY, "Input_ifc_negotiation result: failed (error while receiving hello message from output interface).");
-      return TRAP_E_FIELDS_MISMATCH;
+      return TRAP_E_NEGOTIATION_FAILED;
 
    case NEG_RES_FMT_MISMATCH:
       VERBOSE(CL_VERBOSE_LIBRARY, "Input_ifc_negotiation result: failed (data type or data format specifier mismatch).");

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1332,7 +1332,7 @@ static void *sending_thread_func(void *priv)
 
             /* Disconnect clients that are unable to receive data fast enough and are blocking the whole module. */
             disconnect_client(c, i);
-            VERBOSE(CL_VERBOSE_ADVANCED, "Sending thread: Client %" PRIu32 " could not receive data fast enough and was disconnected", i);
+            VERBOSE(CL_VERBOSE_ADVANCED, "Sending thread: Client %" PRIu32 " could not receive data fast enough and was disconnected", cl->id);
          }
          continue;
       }
@@ -1361,7 +1361,7 @@ static void *sending_thread_func(void *priv)
             res = recv(cl->sd, buffer, DEFAULT_MAX_DATA_LENGTH, 0);
             if (res < 1) {
                disconnect_client(c, i);
-               VERBOSE(CL_VERBOSE_LIBRARY, "Sending thread: Client %u disconnected", cl->id);
+               VERBOSE(CL_VERBOSE_LIBRARY, "Sending thread: Client %" PRIu32 " disconnected", cl->id);
                continue;
             }
          }
@@ -1377,7 +1377,7 @@ static void *sending_thread_func(void *priv)
             cl->timer_total += cl->timer_last;
 
             if (res != TRAP_E_OK) {
-               VERBOSE(CL_VERBOSE_OFF, "Sending thread: Disconnected client %d (ret val: %d)", cl->id, res);
+               VERBOSE(CL_VERBOSE_OFF, "Sending thread: Disconnected client %" PRIu32 " (ret val: %d)", cl->id, res);
                disconnect_client(c, i);
             }
          }

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1319,6 +1319,21 @@ static void *sending_thread_func(void *priv)
          }
       } else if (res == 0) {
          /* Select timed out - no client will be receiving */
+         for (i = 0; i < c->clients_arr_size; ++i) {
+            if (check_index(c->clients_bit_arr, i) == 0) {
+               continue;
+            }
+
+            cl = &(c->clients[i]);
+            assigned_buffer = &c->buffers[cl->assigned_buffer];
+            if (check_index(assigned_buffer->clients_bit_arr, i) == 0) {
+               continue;
+            }
+
+            /* Disconnect clients that are unable to receive data fast enough and are blocking the whole module. */
+            disconnect_client(c, i);
+            VERBOSE(CL_VERBOSE_ADVANCED, "Sending thread: Client %" PRIu32 " could not receive data fast enough and was disconnected", i);
+         }
          continue;
       }
 

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1104,7 +1104,7 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
 
       case NEG_RES_FAILED:
          VERBOSE(CL_VERBOSE_LIBRARY, "Input_ifc_negotiation result: failed (error while receiving hello message from output interface).");
-         return TRAP_E_FIELDS_MISMATCH;
+         return TRAP_E_NEGOTIATION_FAILED;
 
       case NEG_RES_FMT_MISMATCH:
          VERBOSE(CL_VERBOSE_LIBRARY, "Input_ifc_negotiation result: failed (data type or data format specifier mismatch).");


### PR DESCRIPTION
- Fixed autoflush not being called when sending thread was sleeping (module was not able to send data until buffer was full)
- Fixed bug where one slow reading / idle client could block the entire module. This could happen with `WAIT`, `HALF_WAIT` or `NO_WAIT` timeouts.

Bug scenario:
```
flow source -> traffic_repeater -> flow_counter1
            -> flow_counter2
```
When we stop the `flow_counter1` module and `traffic_repeater` is still running, `flow_counter2` would not be able to receive any data from `flow source`.