### PR TITLE
libtrap: replace select with poll

### DIFF
--- a/libtrap/src/ifc_tcpip_internal.h
+++ b/libtrap/src/ifc_tcpip_internal.h
@@ -100,6 +100,8 @@ typedef struct tcpip_sender_private_s {
    buffer_t *buffers;                      /**< Array of buffer structures */
    client_t *clients;                      /**< Array of client structures */
 
+   struct pollfd *clients_pfds;            /**< Array of clients pfds for poll */
+
    pthread_t accept_thr;                   /**< Pthread structure containing info about accept thread */
    pthread_t send_thr;                     /**< Pthread structure containing info about sending thread */
 


### PR DESCRIPTION
Select has limited range of file descriptors form 0-1023 https://man7.org/linux/man-pages/man2/select.2.html

>  POSIX allows an implementation to define an upper limit, advertised
       via the constant FD_SETSIZE, on the range of file descriptors that
       can be specified in a file descriptor set.  The Linux kernel imposes
       no fixed limit, but the glibc implementation makes fd_set a fixed-
       size type, with FD_SETSIZE defined as 1024, and the FD_*() macros
       operating according to that limit.  To monitor file descriptors
       greater than 1023, use poll(2) or epoll(7) instead.

Unfortunately, this behavior causes problems in Flowmon Networks, since file descriptors greater than 1023 are quite common.