### PR TITLE
README: Add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ The framework consists of:
  * [pytrap](./pytrap) -- python wrapper for libtrap and UniRec that allows development of nemea modules in python
  * [pycommon](./pycommon) -- python common modules and methods, there is currently a support of alerts creation in the [IDEA](https://idea.cesnet.cz/en/index) format that can be stored into MongoDB or sent to the [Warden](https://wardenw.cesnet.cz/) incident sharing system
 
+Dependencies
+============
+
+To be able to compile Nemea Framework on GNU/Linux distributions, you will need to have installed on your system the following depencies which were needed on Ubuntu 20.04 LTS:
+
+```
+make autoreconf libtool libxml2-dev
+```
 
 Installation
 ============


### PR DESCRIPTION
Hopefully, this will save someone time as I didn't have installed
autoreconf, libtool and libxml2-dev on Ubuntu 20.04.
Let's start with some dependencies they could be extended in the future.