### PR TITLE
unirec.c: fix warning about deprecated _BSD_SOURCE

### DIFF
--- a/unirec/unirec.c
+++ b/unirec/unirec.c
@@ -43,6 +43,7 @@
  *
  */
 
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #define _XOPEN_SOURCE
 #define __USE_XOPEN


### PR DESCRIPTION
Fixes warning:
warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]

In man pages:
```
To allow code that requires _BSD_SOURCE in glibc 2.19
and earlier and _DEFAULT_SOURCE in glibc 2.20 and
later to compile without warnings, define both _BSD_SOURCE and _DEFAULT_SOURCE.
```