### PR TITLE
treewide: prefer Python3 instead of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Python parts must be installed separately when needed.
 It can be done using:
 
 ```
-cd pytrap; sudo python setup.py install
+cd pytrap; sudo python3 setup.py install
 ```
 and
 ```
-cd pycommon; sudo python setup.py install
+cd pycommon; sudo python3 setup.py install
 ```
 
 Project status:

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_CC
 
 # Check for rpmbuild
 AC_CHECK_PROG(RPMBUILD, rpmbuild, rpmbuild, [""])
-AC_CHECK_PROG(PYTHON, python, python, [""])
+AC_CHECK_PROG(PYTHON, python3, python3, [""])
 AC_SUBST(PYTHON)
 
 # Checks for header files.

--- a/pycommon/README
+++ b/pycommon/README
@@ -8,7 +8,7 @@ Currently, it is used by reporter modules.
 Run as root:
 
 ```
-python setup.py install
+python3 setup.py install
 ```
 
 Note: for different versions of python, it is needed to perform this command

--- a/pytrap/README
+++ b/pytrap/README
@@ -14,7 +14,7 @@ must be installed in the system.
 When all requirements are met, run as root:
 
 ```
-python setup.py install
+python3 setup.py install
 ```
 
 Note: for different versions of python, it is needed to perform this command


### PR DESCRIPTION
When I compiled it successfully on Ubuntu 20.04 LTS,
there was the following advise:

```
For installation of Python components run the following commands as root:
(cd pytrap; python setup.py install --record=installed-files.txt;)
(cd pycommon; python setup.py install --record=installed-files.txt;)
```

This ends up in my case that I don't have installed setuptools, but it
was trying to install for Python2. When I used python3
setup.py, it works. Let's force users to use python3.

Ubuntu provides package python-is-python2 by default.
User can choose if he wants to have this or python-is-python3.
If you don't have symlink for python, it is better to use python3.
On the other hand, Arch Linux symlinks python to python3. On Gentoo,
the choise is up user. Commonly python should be linked to python3 in
some way.

More details are in [PEP 394](https://www.python.org/dev/peps/pep-0394/). Since, there is removed python2 support for
[pytrap](https://github.com/CESNET/Nemea-Framework/commit/c7ae64e14a4343c2ba9d486d51882a178d14d521) and [pycommon](https://github.com/CESNET/Nemea-Framework/commit/27837a79547728b6bc595bed19c60647daf2462b) and in shebangs you are using Python3, there should be python3
and [in spec file](https://github.com/CESNET/Nemea-Framework/commit/4bfbb92d1338d4fcb42c6bd5abc712c01570234f) there is explicit dependency on Python3 packages.

python should be used if it is possible to use Python2 or Python3.