### PR TITLE
Refactor

### DIFF
--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -540,7 +540,7 @@ void switch_file_wrapper(void *priv)
 {
    file_private_t *c = (file_private_t *) priv;
    if (c && !c->is_terminated && (create_next_filename(c) == TRAP_E_OK)) {
-      if(switch_file(c) != TRAP_E_OK) {
+      if (switch_file(c) != TRAP_E_OK) {
          VERBOSE(CL_WARNING, "disconnect_clients sub function switch_file failed.");
       }
    }
@@ -907,4 +907,3 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
 /**
  * @}
  *//* ifc modules */
-

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -844,7 +844,7 @@ int create_file_send_ifc(trap_ctx_priv_t *ctx, const char *params, trap_output_i
             if (strlen(priv->filename_tmplt) + TIME_FORMAT_STRING_LEN > sizeof(priv->filename_tmplt) - 1) {
                free(priv->buffer.header);
                free(priv);
-               return trap_errorf(ctx, TRAP_E_BADPARAMS, "FILE OUTPUT IFC[%"PRIu32"]: Path and filename exceeds maximum size: %u.", idx, sizeof(priv->filename_tmplt) - 1);
+               return trap_errorf(ctx, TRAP_E_BADPARAMS, "FILE OUTPUT IFC[%"PRIu32"]: Path and filename exceeds maximum size: %zu.", idx, sizeof(priv->filename_tmplt) - 1);
             }
 
             /* Append timestamp formate to the current template */

--- a/libtrap/src/ifc_file.c
+++ b/libtrap/src/ifc_file.c
@@ -540,7 +540,9 @@ void switch_file_wrapper(void *priv)
 {
    file_private_t *c = (file_private_t *) priv;
    if (c && !c->is_terminated && (create_next_filename(c) == TRAP_E_OK)) {
-      switch_file(c);
+      if(switch_file(c) != TRAP_E_OK) {
+         VERBOSE(CL_WARNING, "disconnect_clients sub function switch_file failed.");
+      }
    }
 }
 /**

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -910,7 +910,7 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
    }
 
    if (rv != TRAP_E_OK) { /*something went wrong while setting up connection */
-      if(sockfd >= 0) {
+      if (sockfd >= 0) {
          close(sockfd);
       }
       return rv;

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -910,6 +910,9 @@ static int client_socket_connect(void *priv, const char *dest_addr, const char *
    }
 
    if (rv != TRAP_E_OK) { /*something went wrong while setting up connection */
+      if(sockfd >= 0) {
+         close(sockfd);
+      }
       return rv;
    }
 

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1020,7 +1020,7 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
    /* catching all possible errors from setting up socket before atempting tls handshake */
    if (rv != TRAP_E_OK) {
       freeaddrinfo(servinfo);
-      if(sockfd > 0)
+      if(sockfd >= 0)
          close(sockfd);
       return rv;
    }

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1487,7 +1487,10 @@ static void *sending_thread_func(void *priv)
          cl = &(c->clients[i]);
          assigned_buffer = &c->buffers[cl->assigned_buffer];
 
-         FD_SET(cl->sd, &disset);
+         if (cl->sd >= 0) {
+            FD_SET(cl->sd, &disset);
+         }
+
          if (maxsd < cl->sd) {
             maxsd = cl->sd;
          }
@@ -1502,7 +1505,9 @@ static void *sending_thread_func(void *priv)
             cl->pending_bytes = ntohl(*((uint32_t *) assigned_buffer->header)) + sizeof(uint32_t);
          }
 
-         FD_SET(cl->sd, &set);
+         if (cl->sd >= 0) {
+            FD_SET(cl->sd, &set);
+         }
       }
 
       if (waiting_clients == c->connected_clients) {

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1020,7 +1020,8 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
    /* catching all possible errors from setting up socket before atempting tls handshake */
    if (rv != TRAP_E_OK) {
       freeaddrinfo(servinfo);
-      close(sockfd);
+      if(sockfd > 0)
+         close(sockfd);
       return rv;
    }
 

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1020,7 +1020,7 @@ static int client_socket_connect(tls_receiver_private_t *c, struct timeval *tv)
    /* catching all possible errors from setting up socket before atempting tls handshake */
    if (rv != TRAP_E_OK) {
       freeaddrinfo(servinfo);
-      if(sockfd >= 0)
+      if (sockfd >= 0)
          close(sockfd);
       return rv;
    }
@@ -2167,4 +2167,3 @@ static int server_socket_open(void *priv)
 /**
  * @}
  *//* ifc modules */
-

--- a/libtrap/src/third-party/libjansson/load.c
+++ b/libtrap/src/third-party/libjansson/load.c
@@ -339,7 +339,7 @@ static void lex_scan_string(lex_t *lex, json_error_t *error)
             /* control character */
             lex_unget_unsave(lex, c);
             if(c == '\n')
-                error_set(error, lex, "unexpected newline", c);
+                error_set(error, lex, "unexpected newline");
             else
                 error_set(error, lex, "control character 0x%x", c);
             goto out;

--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -1449,11 +1449,10 @@ int trap_ctx_send(trap_ctx_t *ctx, unsigned int ifc, const void *data, uint16_t 
 {
    int ret_val = TRAP_E_OK;
    trap_ctx_priv_t *c = (trap_ctx_priv_t *) ctx;
-   trap_output_ifc_t* ifc_ptr = &c->out_ifc_list[ifc];
-
    if (c == NULL || c->initialized == 0) {
       return TRAP_E_NOT_INITIALIZED;
    }
+   trap_output_ifc_t* ifc_ptr = &c->out_ifc_list[ifc];
 
    if (c->terminated) {
       return trap_error(c, TRAP_E_TERMINATED);

--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -2423,7 +2423,7 @@ void *service_thread_routine(void *arg)
             }
             /* not enough space, go away */
             int accept_retval = accept(priv->server_sd, NULL, NULL);
-            if(accept_retval > 0)
+            if(accept_retval >= 0)
                close(accept_retval);
 accept_success:
             continue;

--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -2423,8 +2423,9 @@ void *service_thread_routine(void *arg)
             }
             /* not enough space, go away */
             int accept_retval = accept(priv->server_sd, NULL, NULL);
-            if(accept_retval >= 0)
+            if (accept_retval >= 0) {
                close(accept_retval);
+            }
 accept_success:
             continue;
          }

--- a/libtrap/src/trap.c
+++ b/libtrap/src/trap.c
@@ -2423,7 +2423,9 @@ void *service_thread_routine(void *arg)
                }
             }
             /* not enough space, go away */
-            close(accept(priv->server_sd, NULL, NULL));
+            int accept_retval = accept(priv->server_sd, NULL, NULL);
+            if(accept_retval > 0)
+               close(accept_retval);
 accept_success:
             continue;
          }

--- a/libtrap/tests/test_echo.c
+++ b/libtrap/tests/test_echo.c
@@ -138,8 +138,12 @@ int main(int argc, char **argv)
       while ((opt = getopt(argc, argv, options)) != ERRARG) {
          switch (opt) {
          case 'n':
-            sscanf(optarg, "%hu", &payload_size);
-            payload = (char *) calloc(1, payload_size);
+            if (sscanf(optarg, "%hu", &payload_size) == 1) {
+               payload = (char *) calloc(1, payload_size);
+            } else {
+               fprintf(stderr, "ERROR parameter n required integer\n");
+               return 1;
+            }
          }
       }
    }

--- a/libtrap/tests/test_echo_ctx.c
+++ b/libtrap/tests/test_echo_ctx.c
@@ -130,8 +130,12 @@ int main(int argc, char **argv)
       while ((opt = getopt(argc, argv, options)) != ERRARG) {
          switch (opt) {
          case 'n':
-            sscanf(optarg, "%hu", &payload_size);
-            payload = (char *) calloc(1, payload_size);
+            if (sscanf(optarg, "%hu", &payload_size) == 1) {
+               payload = (char *) calloc(1, payload_size);
+            } else {
+               fprintf(stderr, "ERROR parameter n required integer\n");
+               return 1;
+            }
          }
       }
    }

--- a/libtrap/tests/test_rxtx.c
+++ b/libtrap/tests/test_rxtx.c
@@ -136,7 +136,12 @@ int main(int argc, char **argv)
          switch (opt) {
          case 'n':
             sscanf(optarg, "%hu", &payload_size);
-            payload = (char *) calloc(1, payload_size);
+            if (sscanf(optarg, "%hu", &payload_size) == 1) {
+               payload = (char *) calloc(1, payload_size);
+            } else {
+               fprintf(stderr, "ERROR parameter n required integer\n");
+               return 1;
+            }
             break;
          case 's':
             send = start_tx_first = 1;

--- a/unirec/ip_prefix_search.c
+++ b/unirec/ip_prefix_search.c
@@ -86,10 +86,10 @@ uint32_t **create_ip_v6_net_mask_array()
          return NULL;
       }
       // Fill every word of IPv6 address
-      net_mask_array[i][0] = 0xFFFFFFFF >> (i == 0  || i >= 32 ? 0 : 32  - i);
-      net_mask_array[i][1] = 0xFFFFFFFF >> (i <= 32 || i >= 64 ? 0 : 64  - i);
-      net_mask_array[i][2] = 0xFFFFFFFF >> (i <= 64 || i >= 96 ? 0 : 96  - i);
-      net_mask_array[i][3] = 0xFFFFFFFF >> (i <= 96            ? 0 : 128 - i);
+      net_mask_array[i][0] = 0xFFFFFFFF >> (i == 0 || i >= 32 ? 0 : 32  - i);
+      net_mask_array[i][1] = i <= 32 ? 0 : 0xFFFFFFFF >> (i >= 64 ? 0 : 64  - i);
+      net_mask_array[i][2] = i <= 64 ? 0 : 0xFFFFFFFF >> (i >= 96 ? 0 : 96  - i);
+      net_mask_array[i][3] = i <= 96 ? 0 : 0xFFFFFFFF >> (128 - i);
 
       // Swap bits in every byte for compatibility with ip_addr_t stucture
       for (j = 0; j < 4; ++j) {

--- a/unirec/ip_prefix_search.c
+++ b/unirec/ip_prefix_search.c
@@ -83,10 +83,10 @@ uint32_t **create_ip_v6_net_mask_array()
          return NULL;
       }
       // Fill every word of IPv6 address
-      net_mask_array[i][0] = 0xFFFFFFFF>>(i > 31 ? 0 : 32 - i);
-      net_mask_array[i][1] = 0xFFFFFFFF>>(i > 63 ? 0 : (i > 32 ? 64 - i: 32));
-      net_mask_array[i][2] = 0xFFFFFFFF>>(i > 95 ? 0 : (i > 64 ? 96 - i: 32));
-      net_mask_array[i][3] = 0xFFFFFFFF>>(i > 127 ? 0 : (i > 96 ? 128 - i : 32));
+      net_mask_array[i][0] = 0xFFFFFFFF >> (i == 0  || i >= 32 ? 0 : 32  - i);
+      net_mask_array[i][1] = 0xFFFFFFFF >> (i <= 32 || i >= 64 ? 0 : 64  - i);
+      net_mask_array[i][2] = 0xFFFFFFFF >> (i <= 64 || i >= 96 ? 0 : 96  - i);
+      net_mask_array[i][3] = 0xFFFFFFFF >> (i <= 96            ? 0 : 128 - i);
 
       // Swap bits in every byte for compatibility with ip_addr_t stucture
       for (j = 0; j < 4; ++j) {

--- a/unirec/ip_prefix_search.c
+++ b/unirec/ip_prefix_search.c
@@ -513,7 +513,6 @@ ipps_context_t *ipps_init(ipps_network_list_t *network_list)
       if (prefix_context->v6_prefix_intervals == NULL) {
          destroy_ip_v6_net_mask_array(net_mask_array);
          ipps_destroy(prefix_context);
-         free(prefix_context);
          return NULL;
       }
 

--- a/unirec/ip_prefix_search.c
+++ b/unirec/ip_prefix_search.c
@@ -80,7 +80,7 @@ uint32_t **create_ip_v6_net_mask_array()
    for (i = 0; i < 129; i++) {
       net_mask_array[i] = malloc(4 * sizeof(uint32_t));
       if (net_mask_array[i] == NULL) {
-         for(int k = 0; k < i; k++) {
+         for (int k = 0; k < i; k++) {
             free(net_mask_array[i]);
          }
          return NULL;

--- a/unirec/ip_prefix_search.c
+++ b/unirec/ip_prefix_search.c
@@ -820,7 +820,10 @@ ipps_interval_t *init_context( ipps_network_t **networks, uint32_t network_count
                      end_of_list = conductor->next;
                   }
                   memcpy(&conductor->interval->high_ip,  &current_interval.high_ip, 16);
-                  add_data(conductor->interval, networks[index]->data, networks[index]->data_len);
+                  if (add_data(conductor->interval, networks[index]->data, networks[index]->data_len)) {
+                     destroy_list(interval_list);
+                     return  NULL;
+                  }
 
                   break;
                } else if (ip_cmp_result < 0) {

--- a/unirec/unirec.c
+++ b/unirec/unirec.c
@@ -1587,7 +1587,9 @@ int ur_set_from_string(const ur_template_t *tmpl, void *data, ur_field_id_t f_id
          ur_var_change_size(tmpl, data, f_id, size);
          unsigned char *data_ptr = ur_get_ptr_by_id(tmpl, data, f_id);
          for ( ; size > 0; --size, v += 2, ++data_ptr) {
-            sscanf(v, "%2hhx", data_ptr);
+            if (sscanf(v, "%2hhx", data_ptr) != 1) {
+               rv = 1;
+            }
          }
       }
       break;


### PR DESCRIPTION
## Report

### Argument cannot be negative

   - related to the socket descriptor as a parameter in the close function. Coverity complains about the possible negative value of the descriptor.

### Bad bit shift operation

#### ifc_tls.c

   - macro FD_SET() in file libtrap/src/ifc_tls.c must not perform a shift operation with a negative value, otherwise undefined behavior will occur.
   - Please consider whether a command should be added that prints a warning or if this solution is OK at all.

#### ip_prefix_search.c

   - A bit shift operation has a shift amount which is too large. There is a risk of undefined behavior.
   - It is possible that a bug was discovered, because the regularity of the mask is strange.

Try it yourself with this code (compile with gcc with -std=c99) and uncomment first print block:

```C++
#include <stdio.h>
#include <stdint.h>

void printBits(size_t const size, void const * const ptr)
{
   unsigned char *b = (unsigned char*) ptr;
   unsigned char byte;
   int i, j;

   for (i = size-1; i >= 0; i--) {
      for (j = 7; j >= 0; j--) {
         byte = (b[i] >> j) & 1;
         printf("%u", byte);
      }
   }
}

static void test()
{
   for(int i = 0; i < 129; i++) {
      // OLD SHIFTS
      uint32_t value1a = 0xFFFFFFFF>>(i > 31 ? 0 : 32 - i);
      uint32_t value2a = 0xFFFFFFFF>>(i > 63 ? 0 : (i > 32 ? 64 - i: 32));
      uint32_t value3a = 0xFFFFFFFF>>(i > 95 ? 0 : (i > 64 ? 96 - i: 32));
      uint32_t value4a = 0xFFFFFFFF>>(i > 127 ? 0 : (i > 96 ? 128 - i : 32));

      // REFACTORED SHIFTS
      uint32_t value1b = 0xFFFFFFFF >> (i == 0 || i >= 32 ? 0 : 32  - i);
      uint32_t value2b = i <= 32 ? 0 : 0xFFFFFFFF >> (i >= 64 ? 0 : 64  - i);
      uint32_t value3b = i <= 64 ? 0 : 0xFFFFFFFF >> (i >= 96 ? 0 : 96  - i);
      uint32_t value4b = i <= 96 ? 0 : 0xFFFFFFFF >> (128 - i);

      // UNCOMMENT IF YOU WANT SEE ORIGINAL RESULTS
      /*
      printBits(sizeof(uint32_t), &value1a);
      printf(" ");
      printBits(sizeof(uint32_t), &value2a);
      printf(" ");
      printBits(sizeof(uint32_t), &value3a);
      printf(" ");
      printBits(sizeof(uint32_t), &value4a);
      */
      
      //printf("\n------------------------------------------------\n");
      
      // UNCOMMENT IF YOU WANT CHECK NEW RESULTS
      /*
      printBits(sizeof(uint32_t), &value1b);
      printf(" ");
      printBits(sizeof(uint32_t), &value2b);
      printf(" ");
      printBits(sizeof(uint32_t), &value3b);
      printf(" ");
      printBits(sizeof(uint32_t), &value4b);
      */
      
      //puts("");

      if(value1a != value1b) {
         printf("%d error- %u vs %u\n", i, value1a, value1b);
      } else if(value2a != value2b) {
         printf("%d error- %u vs %u\n", i, value2a, value2b);
      } else if(value3a != value3b) {
         printf("%d error- %u vs %u\n", i, value3a, value3b);
      } else if(value4a != value4b) {
         printf("%d error- %u vs %u\n", i, value4a, value4b);
      }
   }
}

int main()
{
   test();
   return 0;
}
```

### Resource leak, Double free

   - The ip_prefix_search module does not free memory in the event of an error. It may not be serious, but I think that these problems shouldn't be in the Nemea-Framework.

### Unchecked return value

   - Please see libtrap/src/ifc_file.c:543 if this solution is OK, or you will need to modify the return type of the switch_file_wrapper function to respond to an error in the switch_file function

### Other small mistakes

   - Extra argument to printf format specifier
   - Dereference before null check
   - Buffer not null terminated
   - Invalid type in argument to printf format specifier
