### PR TITLE
libtrap: Fix build on GCC v10.x

### DIFF
--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -46,19 +46,6 @@ AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 AM_CONDITIONAL([GCC], [test x$GCC = xyes])
 
-# Check the version of the compiler, if gcc is used and it is newer than 10, we
-# need -fcommon in CFLAGS
-if test x"$CC" = xgcc; then
-    AC_MSG_CHECKING([for version of compiler])
-    compiler_version="`$CC -dumpversion`"
-    if test "$compiler_version" -ge 10 2>/dev/null ; then
-        CFLAGS="$CFLAGS -fcommon"
-	AC_MSG_RESULT([$compiler_version -> adding -fcommon into CFLAGS])
-    else
-	AC_MSG_RESULT([$compiler_version])
-    fi
-fi
-
 # Check for rpmbuild
 AC_CHECK_PROG(RPMBUILD, rpmbuild, rpmbuild, [""])
 AC_CHECK_PROG(DEBUILD, debuild, debuild, [""])

--- a/libtrap/src/trap_internal.c
+++ b/libtrap/src/trap_internal.c
@@ -55,6 +55,7 @@
  */
 int trap_debug = 0;
 int trap_verbose = -1;
+char trap_err_msg[4096];
 
 /**
  * \brief Return syslog and output level based on given verbose level

--- a/libtrap/src/trap_internal.h
+++ b/libtrap/src/trap_internal.h
@@ -94,7 +94,7 @@ extern int trap_debug;
 /*! control verbose level */
 extern int trap_verbose;
 /*! buffer for verbose and debug messages */
-char trap_err_msg[4096];
+extern char trap_err_msg[];
 
 typedef struct trap_ctx_priv_s trap_ctx_priv_t;
 


### PR DESCRIPTION
* Move the definition of char trap_err_msg[] from header file to
  source file and declare the variable as extern in the header.
* GCC since v10.0 changes default handling of tentatively defined
  global variables to be in accordance with the C standard, what
  inhibits their merging by linker on multiple definition. While
  it is possible to work around this behaviour by forcing -fcommon,
  the better approach is to fix the definitions as is done here.
* For additional details see:
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678