### PR TITLE
pytrap: support str object in TrapCtx.send()

### DIFF
--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -157,6 +157,8 @@ pytrap_send(pytrap_trapcontext *self, PyObject *args, PyObject *keywds)
         data = PyByteArray_AsString(dataObj);
     } else if (PyBytes_Check(dataObj)) {
         PyBytes_AsStringAndSize(dataObj, &data, &data_size);
+    } else if (PyUnicode_Check(dataObj)) {
+        data = PyUnicode_AsUTF8AndSize(dataObj, &data_size);
     } else {
         PyErr_SetString(PyExc_TypeError, "Argument data must be of bytes or bytearray type.");
         return NULL;

--- a/pytrap/test/pytrapmodule_unittest.py
+++ b/pytrap/test/pytrapmodule_unittest.py
@@ -163,3 +163,29 @@ class StoreAndLoadMessage(unittest.TestCase):
 
         os.unlink("/tmp/pytrap_test")
 
+class StoreAndLoadStringMessage(unittest.TestCase):
+    def runTest(self):
+        """json.dump returns str object, which was formerly not supported by pytrep send()"""
+        import pytrap
+        import json
+        import os
+
+        urtempl = "test"
+        jdata = {"SRC_IP": "192.168.0.1"}
+        c = pytrap.TrapCtx()
+        c.init(["-i", "f:/tmp/pytrap_test2"], 0, 1)
+        c.setDataFmt(0, pytrap.FMT_JSON, urtempl)
+
+        c.send(json.dumps(jdata))
+        c.sendFlush()
+        c.finalize()
+
+        c = pytrap.TrapCtx()
+        c.init(["-i", "f:/tmp/pytrap_test2"], 1)
+        c.setRequiredFmt(0, pytrap.FMT_JSON, urtempl)
+        data = c.recv()
+        c.finalize()
+        self.assertEqual(jdata, json.loads(data))
+
+        os.unlink("/tmp/pytrap_test2")
+


### PR DESCRIPTION
Unsupported str causes exception in the following code:
`trap.send(json.dumps(j))`

This PR should fix this issue (adding this support).
The test `pytrap/test/pytrapmodule_unittest.py` fails for the previous version.