### PR TITLE
pytrap: add read_nemea() returns pandas.DataFrame or list(dict)

### DIFF
--- a/pytrap/setup.py
+++ b/pytrap/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, Extension
 import os
 
-SRC_PATH = os.path.relpath(os.path.join(os.path.dirname(__file__), "."))
+SRC_PATH = os.path.relpath(os.path.join(os.path.dirname(__file__), ".", "src"))
 
-pytrapmodule = Extension('pytrap',
+pytrapmodule = Extension('pytrap.pytrap',
                     sources = ['src/pytrapmodule.c', 'src/unirecmodule.c', 'src/unirecipaddr.c', 'src/unirecmacaddr.c', 'src/fields.c'],
                     libraries = ['trap', 'unirec'])
 
@@ -31,6 +31,7 @@ setup(name = 'nemea-pytrap',
               'Topic :: System :: Networking :: Monitoring'
        ],
        ext_modules = [pytrapmodule],
+       packages = ["pytrap"],
        package_dir={ "": SRC_PATH, },
        )
 

--- a/pytrap/src/pytrap/__init__.py
+++ b/pytrap/src/pytrap/__init__.py
@@ -1,0 +1,52 @@
+from pytrap.pytrap import *
+
+def read_nemea(ifc_spec, nrows=-1, array=False):
+    """
+    Read `nrows` records from NEMEA TRAP interface given by `ifc_spec` and convert then into Pandas DataFrame.
+
+    Args:
+        ifc_spec (str): IFC specifier for TRAP input IFC, see https://nemea.liberouter.org/trap-ifcspec/
+        nrows (int): Number of records, read until end of stream (zero size message) if -1.
+        array (bool): Set output type to list of dictionary instead of pandas.DataFrame
+
+    Returns:
+        pandas.DataFrame or list of dictionary: DataFrame if array is False, otherwise, list of dictionary
+
+    Raises:
+        ModuleNotFoundError: When pandas is not installed.
+    """
+    c = pytrap.TrapCtx()
+    c.init(["-i", ifc_spec], 1, 0)
+    c.setRequiredFmt(0)
+    rec = None
+    l = list()
+    while nrows != 0:
+        try:
+            data = c.recv()
+        except pytrap.FormatChanged as e:
+            fmttype, fmtspec = c.getDataFmt(0)
+            rec = pytrap.UnirecTemplate(fmtspec)
+            data = e.data
+        if len(data) <= 1:
+            break
+        rec.setData(data)
+        d = rec.getDict()
+        if d:
+            l.append(d)
+        if nrows > 0:
+            nrows = nrows - 1
+    c.finalize()
+    del(c)
+    if array:
+        return l
+    else:
+        import pandas as pd
+        return pd.DataFrame(l)
+
+try:
+    import pandas as pd
+    pd.read_nemea = read_nemea
+except ModuleNotFoundError:
+    pass
+
+

--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -631,7 +631,7 @@ static PyMethodDef pytrap_methods[] = {
 
 static struct PyModuleDef pytrapmodule = {
     PyModuleDef_HEAD_INIT,
-    "pytrap",   /* name of module */
+    "pytrap.pytrap",   /* name of module */
     DOCSTRING_MODULE,
     -1,   /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
     pytrap_methods, NULL, NULL, NULL, NULL
@@ -653,7 +653,7 @@ initpytrap(void)
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&pytrapmodule);
 #else
-    m = Py_InitModule3("pytrap", pytrap_methods, DOCSTRING_MODULE);
+    m = Py_InitModule3("pytrap.pytrap", pytrap_methods, DOCSTRING_MODULE);
 #endif
     if (m == NULL) {
         INITERROR;


### PR DESCRIPTION
The new method read_nemea() works as follows:

```
Read `nrows` records from NEMEA TRAP interface given by `ifc_spec` and convert then into Pandas DataFrame.

Args:
  ifc_spec (str): IFC specifier for TRAP input IFC, see https://nemea.liberouter.org/trap-ifcspec/
  nrows (int): Number of records, read until end of stream (zero size message) if -1.
  array (bool): Set output type to list of dictionary instead of pandas.DataFrame

Returns:
  pandas.DataFrame or list of dictionary: DataFrame if array is False, otherwise, list of dictionary

Raises:
  ModuleNotFoundError: When pandas is not installed.
```

The patch also adds UnirecTemplate::getDict() that converts the single
UniRec record into dict().

Example of use:

```
import pytrap

print(pytrap.read_nemea("f:~/osquery.trapcap"))

```