### PR TITLE
report2idea: add `syslog` action

### DIFF
--- a/pycommon/reporter_config/Config.py
+++ b/pycommon/reporter_config/Config.py
@@ -87,6 +87,10 @@ class Config():
                     from .actions.File import FileAction
                     self.actions[i["id"]] = FileAction(i)
 
+                elif "syslog" in i:
+                    from .actions.Syslog import SyslogAction
+                    self.actions[i["id"]] = SyslogAction(i)
+
                 elif "warden" in i:
                     """
                     Pass Warden Client instance to the Warden action

--- a/pycommon/reporter_config/actions/Syslog.py
+++ b/pycommon/reporter_config/actions/Syslog.py
@@ -1,0 +1,64 @@
+from .Action import Action
+
+import json
+import syslog
+import logging as log
+
+logger = log.getLogger(__name__)
+
+class SyslogAction(Action):
+    """Send IDEA message to syslog.
+    The syslog action expects the following parameters in the config file:
+        * identifier (e.g., `nemea`)
+        * logoption - options, can be chained using | (e.g., `LOG_PID | LOG_CONS`)
+        * facility (e.g., `LOG_DAEMON`)
+        * priority (e.g., `LOG_ALERT`)
+    To learn about all possible values, see man syslog.h (https://www.man7.org/linux/man-pages/man0/syslog.h.0p.html)
+    """
+    def __init__(self, action):
+        super(type(self), self).__init__(actionId = action["id"], actionType = "syslog")
+
+        a = action["syslog"]
+
+        self.ident = a.get("identifier", "nemea")
+
+        self.logoption = a.get("logoption", "LOG_PID")
+        self.logoption_code = 0
+        for opt in self.logoption.split("|"):
+            try:
+                self.logoption_code |= self.syslog_lookup_const(opt) 
+            except KeyError:
+                raise Exception(f"Syslog: unknown value {opt} in `logoption`.")
+                
+        self.facility = a.get("facility", "LOG_DAEMON")
+        try:
+            self.facility_code = self.syslog_lookup_const(self.facility)
+        except KeyError:
+            raise Exception(f"Syslog: unknown value {self.facility} in `facility`.")
+
+        self.priority = a.get("priority", "LOG_ALERT")
+        try:
+            self.priority_code = self.syslog_lookup_const(self.priority)
+        except KeyError:
+            raise Exception(f"Syslog: unknown value {self.priority} in `priority`.")
+
+        syslog.openlog(ident=self.ident, logoption=self.logoption_code, facility=self.facility_code)
+
+    def syslog_lookup_const(self, const):
+        """Return value of the string constant from syslog or raise KeyError exception."""
+        retval = vars(syslog).get(const.strip(), None)
+        if not retval:
+            raise KeyError
+        return retval
+
+    def run(self, record):
+        super(type(self), self).run(record)
+        try:
+            syslog.syslog(self.priority_code, json.dumps(record))
+        except Exception as e:
+            self.logger.error(e)
+
+    def __str__(self):
+        return f"Syslog: {self.ident} logoption: {self.logoption} ({self.logoption_code}) facility: {self.facility} ({self.facility_code}) priority: {self.priority} ({self.priority_code})\n"
+
+

--- a/pycommon/test/rc_17_syslog.py
+++ b/pycommon/test/rc_17_syslog.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+import json
+
+from reporter_config.Config import Config, Parser
+
+class RCSyslogTest(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Example message created by a conv function in a reporter
+        """
+        with open(os.path.dirname(__file__) + '/rc_msg.json', 'r') as f:
+            self.msg = json.load(f)
+
+    def tearDown(self):
+        pass
+
+    def test_01_syslogerror_facility(self):
+        """
+        Load malformed syslog configuration file, parse it and analyze it
+        This should rise exception
+        """
+        self.parser = Parser(os.path.dirname(__file__) + '/rc_config/syslog-malformed-facility.yaml');
+        with self.assertRaises(Exception):
+            self.config = Config(self.parser);
+
+    def test_02_syslogerror_priority(self):
+        """
+        Load malformed syslog configuration file, parse it and analyze it
+        This should rise exception
+        """
+        self.parser = Parser(os.path.dirname(__file__) + '/rc_config/syslog-malformed-priority.yaml');
+        with self.assertRaises(Exception):
+            self.config = Config(self.parser);
+
+    def test_03_syslogerror_logoption(self):
+        """
+        Load malformed syslog configuration file, parse it and analyze it
+        This should rise exception
+        """
+        self.parser = Parser(os.path.dirname(__file__) + '/rc_config/syslog-malformed-logoption.yaml');
+        with self.assertRaises(Exception):
+            self.config = Config(self.parser);
+
+    def test_04_syslog(self):
+        """
+        Load email.yaml configuration file, parse it and analyze it
+        This shouldn't rise any exceptions
+        """
+        self.parser = Parser(os.path.dirname(__file__) + '/rc_config/syslog.yaml');
+        self.config = Config(self.parser);
+
+        self.assertNotEqual(self.config, None)
+        self.config.match(self.msg)
+

--- a/pycommon/test/rc_17_syslog.py
+++ b/pycommon/test/rc_17_syslog.py
@@ -45,7 +45,7 @@ class RCSyslogTest(unittest.TestCase):
 
     def test_04_syslog(self):
         """
-        Load email.yaml configuration file, parse it and analyze it
+        Load syslog.yaml configuration file, parse it and analyze it
         This shouldn't rise any exceptions
         """
         self.parser = Parser(os.path.dirname(__file__) + '/rc_config/syslog.yaml');

--- a/pycommon/test/rc_config/syslog-malformed-facility.yaml
+++ b/pycommon/test/rc_config/syslog-malformed-facility.yaml
@@ -1,0 +1,15 @@
+# Configuation for syslog test containing error
+namespace: com.example.nemea
+custom_actions:
+  - id: mysyslog
+    syslog:
+      identifier: NEMEA
+      facility: LOG_NONEXIST
+
+rules:
+- id: 1
+  condition: True
+  actions:
+  - mysyslog
+
+

--- a/pycommon/test/rc_config/syslog-malformed-logoption.yaml
+++ b/pycommon/test/rc_config/syslog-malformed-logoption.yaml
@@ -1,0 +1,16 @@
+# Configuation for syslog test containing error
+namespace: com.example.nemea
+custom_actions:
+  - id: mysyslog
+    syslog:
+      identifier: NEMEA
+      logoption: LOG_PID | LOG_NONEXIST
+
+rules:
+- id: 1
+  condition: True
+  actions:
+  - mysyslog
+
+
+

--- a/pycommon/test/rc_config/syslog-malformed-priority.yaml
+++ b/pycommon/test/rc_config/syslog-malformed-priority.yaml
@@ -1,0 +1,15 @@
+# Configuation for syslog test containing error
+namespace: com.example.nemea
+custom_actions:
+  - id: mysyslog
+    syslog:
+      identifier: NEMEA
+      priority: LOG_NONEXIST
+
+rules:
+- id: 1
+  condition: True
+  actions:
+  - mysyslog
+
+

--- a/pycommon/test/rc_config/syslog.yaml
+++ b/pycommon/test/rc_config/syslog.yaml
@@ -1,0 +1,16 @@
+# Simple Reporter Configuration for Syslog action
+namespace: com.example.nemea
+custom_actions:
+  - id: mysyslog
+    syslog:
+      identifier: NEMEA
+      logoption: LOG_PID | LOG_CONS
+      facility: LOG_DAEMON
+      priority: LOG_ALERT
+
+rules:
+- id: 1
+  condition: True
+  actions:
+  - mysyslog
+


### PR DESCRIPTION
Example config file to define new syslog custom_action is taken from
syslog.yaml test config:

```
namespace: com.example.nemea
custom_actions:
  - id: mysyslog
    syslog:
      identifier: NEMEA
      logoption: LOG_PID | LOG_CONS
      facility: LOG_DAEMON
      priority: LOG_ALERT

rules:
- id: 1
  condition: True
  actions:
  - mysyslog
```