### PR TITLE
pytrap: sendBulk() and other new features

### DIFF
--- a/pytrap/MANIFEST.in
+++ b/pytrap/MANIFEST.in
@@ -1,2 +1,3 @@
 include src/*.c src/*.h README docs/* COPYING
+include src/pytrap/*.py
 include test/*.py

--- a/pytrap/docs/helpers.rst
+++ b/pytrap/docs/helpers.rst
@@ -1,0 +1,8 @@
+pytrap helpers
+==============
+
+.. automodule:: pytrap.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/pytrap/docs/index.rst
+++ b/pytrap/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to pytrap's documentation!
 
    pytrap
    recvbulk
+   helpers
 
 
 Indices and tables

--- a/pytrap/docs/recvbulk.rst
+++ b/pytrap/docs/recvbulk.rst
@@ -49,19 +49,18 @@ recvBulk() Elapsed time for 10000000 messages is: 5.647379766
 Load for pandas DataFrame
 -------------------------
 
-To load data (5 records) into pandas.DataFrame, it is very simple like this:
+To load data (5 records) into pandas.DataFrame, it is very simple like this::
 
->>> import pytrap
->>> pytrap.read_nemea("f:~/pstats.trapcap", nrows=5)
-                     DST_IP                  SRC_IP  BYTES  BYTES_REV  ...            D_PHISTS_SIZES              S_PHISTS_IPT            S_PHISTS_SIZES                                      PPI_PKT_TIMES
-0           185.199.111.133           192.168.1.248    143        143  ...                        []                        []                        []                   [1636152115.816, 1636152115.827]
-1           185.199.111.133           192.168.1.248    143        143  ...  [0, 0, 1, 0, 0, 0, 0, 0]  [0, 0, 0, 0, 0, 0, 0, 0]  [0, 0, 1, 0, 0, 0, 0, 0]                   [1636152115.816, 1636152115.827]
-2               3.68.63.139           192.168.1.248    159        161  ...                        []                        []                        []                   [1636152118.645, 1636152118.668]
-3               3.68.63.139           192.168.1.248    159        161  ...  [0, 0, 1, 0, 0, 0, 0, 0]  [0, 0, 0, 0, 0, 0, 0, 0]  [0, 0, 1, 0, 0, 0, 0, 0]                   [1636152118.645, 1636152118.668]
-4  2a00:1450:4014:80c::200e  2001:470:5828:100::82e   1216       1547  ...                        []                        []                        []  [1636152112.855, 1636152112.856, 1636152112.95...
-
-[5 rows x 25 columns]
->>>
+   >>> import pytrap
+   >>> pytrap.read_nemea("f:~/pstats.trapcap", nrows=5)
+                        DST_IP                  SRC_IP  BYTES  BYTES_REV  ...            D_PHISTS_SIZES              S_PHISTS_IPT            S_PHISTS_SIZES                                      PPI_PKT_TIMES
+   0           185.199.111.133           192.168.1.248    143        143  ...                        []                        []                        []                   [1636152115.816, 1636152115.827]
+   1           185.199.111.133           192.168.1.248    143        143  ...  [0, 0, 1, 0, 0, 0, 0, 0]  [0, 0, 0, 0, 0, 0, 0, 0]  [0, 0, 1, 0, 0, 0, 0, 0]                   [1636152115.816, 1636152115.827]
+   2               3.68.63.139           192.168.1.248    159        161  ...                        []                        []                        []                   [1636152118.645, 1636152118.668]
+   3               3.68.63.139           192.168.1.248    159        161  ...  [0, 0, 1, 0, 0, 0, 0, 0]  [0, 0, 0, 0, 0, 0, 0, 0]  [0, 0, 1, 0, 0, 0, 0, 0]                   [1636152118.645, 1636152118.668]
+   4  2a00:1450:4014:80c::200e  2001:470:5828:100::82e   1216       1547  ...                        []                        []                        []  [1636152112.855, 1636152112.856, 1636152112.95...
+   [5 rows x 25 columns]
+   >>>
 
 Load into array (list)
 ----------------------
@@ -72,3 +71,7 @@ It can be also switched to return array:
 [{'DST_IP': UnirecIPAddr('185.199.111.133'), 'SRC_IP': UnirecIPAddr('192.168.1.248'), 'BYTES': 143, 'BYTES_REV': 143, 'LINK_BIT_FIELD': 1, 'TIME_FIRST': UnirecTime(1636152115, 816), 'TIME_LAST': UnirecTime(1636152115, 827), 'DST_MAC': UnirecMACAddr('ac:84:c6:52:dd:15'), 'SRC_MAC': UnirecMACAddr('d4:3b:04:6d:31:2f'), 'PACKETS': 2, 'PACKETS_REV': 2, 'DST_PORT': 443, 'SRC_PORT': 51922, 'DIR_BIT_FIELD': 0, 'PROTOCOL': 6, 'TCP_FLAGS': 24, 'TCP_FLAGS_REV': 24, 'PPI_PKT_DIRECTIONS': [1, -1], 'PPI_PKT_FLAGS': [24, 24], 'PPI_PKT_LENGTHS': [39, 39], 'D_PHISTS_IPT': [], 'D_PHISTS_SIZES': [], 'S_PHISTS_IPT': [], 'S_PHISTS_SIZES': [], 'PPI_PKT_TIMES': [UnirecTime(1636152115, 816), UnirecTime(1636152115, 827)]}, {'DST_IP': UnirecIPAddr('185.199.111.133'), 'SRC_IP': UnirecIPAddr('192.168.1.248'), 'BYTES': 143, 'BYTES_REV': 143, 'LINK_BIT_FIELD': 1, 'TIME_FIRST': UnirecTime(1636152115, 816), 'TIME_LAST': UnirecTime(1636152115, 827), 'DST_MAC': UnirecMACAddr('ac:84:c6:52:dd:15'), 'SRC_MAC': UnirecMACAddr('d4:3b:04:6d:31:2f'), 'PACKETS': 2, 'PACKETS_REV': 2, 'DST_PORT': 443, 'SRC_PORT': 51922, 'DIR_BIT_FIELD': 0, 'PROTOCOL': 6, 'TCP_FLAGS': 24, 'TCP_FLAGS_REV': 24, 'PPI_PKT_DIRECTIONS': [1, -1], 'PPI_PKT_FLAGS': [24, 24], 'PPI_PKT_LENGTHS': [39, 39], 'D_PHISTS_IPT': [0, 0, 0, 0, 0, 0, 0, 0], 'D_PHISTS_SIZES': [0, 0, 1, 0, 0, 0, 0, 0], 'S_PHISTS_IPT': [0, 0, 0, 0, 0, 0, 0, 0], 'S_PHISTS_SIZES': [0, 0, 1, 0, 0, 0, 0, 0], 'PPI_PKT_TIMES': [UnirecTime(1636152115, 816), UnirecTime(1636152115, 827)]}]
 >>>
 
+Helpers
+.......
+
+See :doc:`helpers` to find useful helpers for loading and storing data.

--- a/pytrap/nemea-pytrap.spec
+++ b/pytrap/nemea-pytrap.spec
@@ -6,8 +6,8 @@
 %endif
 
 Name:           %{pypi_name}
-Version:        0.14.0
-Release:        2%{?dist}
+Version:        0.15.0
+Release:        1%{?dist}
 Summary:        Python extension of the NEMEA project
 
 License:        BSD

--- a/pytrap/setup.py
+++ b/pytrap/setup.py
@@ -4,7 +4,7 @@ import os
 SRC_PATH = os.path.relpath(os.path.join(os.path.dirname(__file__), ".", "src"))
 
 name = 'nemea-pytrap'
-version = '0.14.0'
+version = '0.15.0'
 release = version
 description = 'Python extension of the NEMEA project.'
 long_description = 'The pytrap module is a native Python extension that allows for writing NEMEA modules in Python.'

--- a/pytrap/src/pytrap/__init__.py
+++ b/pytrap/src/pytrap/__init__.py
@@ -1,52 +1,9 @@
+from pytrap.helpers import *
 from pytrap.pytrap import *
-
-def read_nemea(ifc_spec, nrows=-1, array=False):
-    """
-    Read `nrows` records from NEMEA TRAP interface given by `ifc_spec` and convert then into Pandas DataFrame.
-
-    Args:
-        ifc_spec (str): IFC specifier for TRAP input IFC, see https://nemea.liberouter.org/trap-ifcspec/
-        nrows (int): Number of records, read until end of stream (zero size message) if -1.
-        array (bool): Set output type to list of dictionary instead of pandas.DataFrame
-
-    Returns:
-        pandas.DataFrame or list of dictionary: DataFrame if array is False, otherwise, list of dictionary
-
-    Raises:
-        ModuleNotFoundError: When pandas is not installed.
-    """
-    c = pytrap.TrapCtx()
-    c.init(["-i", ifc_spec], 1, 0)
-    c.setRequiredFmt(0)
-    rec = None
-    l = list()
-    while nrows != 0:
-        try:
-            data = c.recv()
-        except pytrap.FormatChanged as e:
-            fmttype, fmtspec = c.getDataFmt(0)
-            rec = pytrap.UnirecTemplate(fmtspec)
-            data = e.data
-        if len(data) <= 1:
-            break
-        rec.setData(data)
-        d = rec.getDict()
-        if d:
-            l.append(d)
-        if nrows > 0:
-            nrows = nrows - 1
-    c.finalize()
-    del(c)
-    if array:
-        return l
-    else:
-        import pandas as pd
-        return pd.DataFrame(l)
 
 try:
     import pandas as pd
     pd.read_nemea = read_nemea
 except ModuleNotFoundError:
     pass
-
 

--- a/pytrap/src/pytrap/helpers.py
+++ b/pytrap/src/pytrap/helpers.py
@@ -1,0 +1,190 @@
+import pytrap
+
+def read_nemea(ifc_spec, nrows=-1, array=False):
+    """
+    Read `nrows` records from NEMEA TRAP interface given by `ifc_spec` and convert then into Pandas DataFrame.
+
+    Example:
+        >>> import pytrap
+        >>> pytrap.read_nemea("f:/tmp/testunirechelper", array=True)
+        [{'SRC_IP': UnirecIPAddr('10.0.0.255'), 'SRC_PORT': 0}, {'SRC_IP': UnirecIPAddr('10.0.0.255'), 'SRC_PORT': 1}, ...]
+
+    Args:
+        ifc_spec (str): IFC specifier for TRAP input IFC, see https://nemea.liberouter.org/trap-ifcspec/
+        nrows (int): Number of records, read until end of stream (zero size message) if -1.
+        array (bool): Set output type to list of dictionary instead of pandas.DataFrame
+
+    Returns:
+        pandas.DataFrame or list of dictionary: DataFrame if array is False, otherwise, list of dictionary
+
+    Raises:
+        ModuleNotFoundError: When pandas is not installed.
+    """
+    c = pytrap.TrapCtx()
+    c.init(["-i", ifc_spec], 1, 0)
+    c.setRequiredFmt(0)
+    rec = None
+    l = list()
+    while nrows != 0:
+        try:
+            data = c.recv()
+        except pytrap.FormatChanged as e:
+            fmttype, fmtspec = c.getDataFmt(0)
+            rec = pytrap.UnirecTemplate(fmtspec)
+            data = e.data
+        if len(data) <= 1:
+            break
+        rec.setData(data)
+        d = rec.getDict()
+        if d:
+            l.append(d)
+        if nrows > 0:
+            nrows = nrows - 1
+    c.finalize()
+    del(c)
+    if array:
+        return l
+    else:
+        import pandas as pd
+        return pd.DataFrame(l)
+
+class PytrapHelperStore():
+    """
+    Easy to use helper for pytrap context with one OUTPUT interface.
+    It provides data_start() to prepare everything, store_record() to send
+    prepared UniRec record, data_stop() to finalize everything.
+
+    The class contains UnirecTemplate accessible via `rec`
+
+    Example 1:
+
+    >>> import pytrap
+    >>> with pytrap.PytrapHelperStore("f:/tmp/testunirechelper:w", "ipaddr SRC_IP,uint16 SRC_PORT") as s:
+    ...     for i in range(10):
+    ...         s.rec.setFromDict({"SRC_IP": "10.0.0.1", "SRC_PORT": i})
+    ...         s.store_record()
+
+    Example 2:
+
+    >>> import pytrap
+    >>> s = pytrap.PytrapHelperStore("f:/tmp/testunirechelper:w", "ipaddr SRC_IP,uint16 SRC_PORT")
+    >>> rec = s.data_start()
+    >>> for i in range(10):
+    ...     rec.setFromDict({"SRC_IP": "10.0.0.255", "SRC_PORT": i})
+    ...     s.store_record()
+    >>> s.data_stop()
+
+    """
+    def __init__(self, ifcspec, fmtspec):
+        """Create new instance of pytrap context with one output interface to send/store data.
+
+        Args:
+            ifcspec (str): TRAP specifier for output interface, see https://nemea.liberouter.org/trap-ifcspec/
+            fmtspec (str): UniRec template specifier
+        """
+        self.ifcspec = ifcspec
+        self.fmtspec = fmtspec
+
+    def __enter__(self):
+        self.data_start()
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self.data_stop()
+
+    def data_start(self):
+        """Start storing the test records into self.filename - initialization."""
+        fmttype = pytrap.FMT_UNIREC
+        self.rec = pytrap.UnirecTemplate(self.fmtspec)
+        self.rec.createMessage(0)
+
+        self.trap = pytrap.TrapCtx()
+        self.trap.init(["-i", self.ifcspec], 0, 1)
+        self.trap.setDataFmt(0, fmttype, self.fmtspec)
+        return self.rec
+
+    def store_record(self):
+        """Store one UniRec record that was filled outside."""
+        if self.trap:
+            self.trap.send(self.rec.getData())
+
+    def data_stop(self):
+        """Finish storing test data."""
+        if self.trap:
+            self.trap.finalize()
+
+class PytrapHelperLoad():
+    """
+    Easy to use helper for pytrap context with one INPUT interface.
+    It provides data_start() to prepare everything, load_record() to receive
+    and return one UniRec record inside UnirecTemplate, data_stop() to finalize
+    everything.
+
+    Example 1:
+
+    >>> import pytrap
+    >>> with pytrap.PytrapHelperLoad("f:/tmp/testunirechelper") as s:
+    ...     rec = s.load_record()
+    ...     while rec:
+    ...         # Do something with record:
+    ...         # print(rec.strRecord())
+    ...         #
+    ...         # Load the next record:
+    ...         rec = s.load_record()
+
+    Example 2:
+
+    >>> import pytrap
+    >>> s = pytrap.PytrapHelperLoad("f:/tmp/testunirechelper")
+    >>> s.data_start()
+    >>> rec = s.load_record()
+    >>> while rec:
+    ...    # Do something with record:
+    ...    # print(rec.strRecord())
+    ...    #
+    ...    # Load the next record:
+    ...    rec = s.load_record()
+    >>> s.data_stop()
+
+    """
+    def __init__(self, ifcspec):
+        self.ifcspec = ifcspec
+
+    def __enter__(self):
+        self.data_start()
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self.data_stop()
+
+    def data_start(self):
+        """Start evaluation of the stored data - initialization."""
+        self.trap = pytrap.TrapCtx()
+        self.trap.init(["-i", self.ifcspec], 1, 0)
+        self.trap.setRequiredFmt(0, pytrap.FMT_UNIREC)
+
+    def load_record(self):
+        """Load one UniRec record and return UnirecTemplate if the record was
+        received. Otherwise, return None when no more data."""
+        try:
+            data = self.trap.recv()
+        except pytrap.FormatChanged as err:
+            fmttype, fmtspec = self.trap.getDataFmt(0)
+            self.rec = pytrap.UnirecTemplate(fmtspec)
+            data = err.data
+        if len(data) <= 1:
+            # empty message - do not process it!!!
+            return None
+
+        self.rec.setData(data)
+        return self.rec
+
+    def data_stop(self):
+        """Finish evaluation."""
+        if self.trap:
+            self.trap.finalize()
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+

--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -772,7 +772,7 @@ static PyMethodDef pytrap_methods[] = {
 "\n" \
 "Simple example to receive and send one message:\n" \
 "\n" \
-"Example:\n" \
+"Examples:\n" \
 "    >>> import pytrap\n" \
 "    >>> c = pytrap.TrapCtx()\n" \
 "    >>> c.init([\"-i\", \"u:socket1,u:socket2\"], 1, 1)\n" \
@@ -797,8 +797,7 @@ static PyMethodDef pytrap_methods[] = {
 "    >>> c.send(data)\n" \
 "    >>> c.finalize()\n" \
 "\n" \
-"Simple example for data access using rec - UnirecTemplate instance:\n\n" \
-"Example:\n" \
+"Simple example for data access using rec - UnirecTemplate instance::\n\n" \
 "    >>> print(rec.SRC_IP)\n" \
 "    >>> rec.SRC_IP = pytrap.UnirecIPAddr(\"127.0.0.1\")\n" \
 "    >>> print(getattr(rec, \"SRC_IP\"))\n" \
@@ -806,8 +805,7 @@ static PyMethodDef pytrap_methods[] = {
 "    >>> print(rec.TIME_FIRST)\n" \
 "    >>> print(rec.TIME_FIRST.toDatetime())\n" \
 "\n" \
-"Simple example for creation of new message of UnirecTemplate:\n" \
-"Example:\n" \
+"Simple example for creation of new message of UnirecTemplate::\n\n" \
 "    >>> # createMessage() expects the maximal total size of fields with variable length as an argument,\n" \
 "    >>> # here it is 100, i.e., size of all variable length data (sum of sizes) MUST be <= 100 bytes\n" \
 "    >>> data = rec.createMessage(100)\n" \
@@ -816,35 +814,28 @@ static PyMethodDef pytrap_methods[] = {
 "createMessage() should be called just at the beginning of program\n" \
 "or when format change is needed.\n" \
 "\n" \
-"It is possible to set JSON format and send JSON documents via TRAP interface.\n" \
-"Example (send):\n" \
-"\n" \
+"It is possible to set JSON format and send JSON documents via TRAP interface.\n\n" \
+"Example - send::\n\n" \
 "    >>> import pytrap\n" \
 "    >>> import json\n" \
 "    >>> c = pytrap.TrapCtx()\n" \
 "    >>> c.init([\"-i\", \"f:/tmp/jsondata.trapcap:w\"], 0, 1)\n" \
 "    >>> c.setDataFmt(0, pytrap.FMT_JSON, \"JSON\")\n" \
-"    >>>\n" \
 "    >>> a = json.dumps({\"a\": 123, \"b\": \"aaa\"})\n" \
-"    >>>\n" \
 "    >>> c.send(bytearray(a, \"utf-8\"))\n" \
-"    >>>\n" \
 "    >>> c.finalize()\n" \
 "\n" \
-"Example (receive):\n" \
-"\n" \
+"Example - receive::\n\n" \
 "    >>> import pytrap\n" \
 "    >>> import json\n" \
 "    >>> c = pytrap.TrapCtx()\n" \
 "    >>> c.init([\"-i\", \"f:/tmp/jsondata.trapcap\"], 1)\n" \
 "    >>> c.setRequiredFmt(0, pytrap.FMT_JSON, \"JSON\")\n" \
-"    >>>\n" \
 "    >>> data = c.recv()\n" \
 "    >>> print(json.loads(data.decode(\"utf-8\")))\n" \
-"    >>>\n" \
 "    >>> c.finalize()\n" \
 "\n" \
-"There are complete example modules, see:\n" \
+"There are some complete example modules, see:\n" \
 "https://github.com/CESNET/Nemea-Framework/tree/master/examples/python\n\n" \
 "For more details, see the generated documentation:\n" \
 "https://nemea.liberouter.org/doc/pytrap/.\n"

--- a/pytrap/src/unirectemplate.h
+++ b/pytrap/src/unirectemplate.h
@@ -28,6 +28,8 @@ PyAPI_FUNC(PyObject *) UnirecTemplate_getDict(pytrap_unirectemplate *self);
 
 PyAPI_FUNC(PyObject *) UnirecTemplate_createMessage(pytrap_unirectemplate *self, uint32_t dynamic_size);
 
+PyAPI_FUNC(PyObject *) UnirecTemplate_setFromDict(pytrap_unirectemplate *self, PyObject *dict, int skip_errors);
+
 PyAPI_FUNC(pytrap_unirectemplate *) UnirecTemplate_init(pytrap_unirectemplate *self);
 
 #ifdef __cplusplus

--- a/pytrap/src/unirectemplate.h
+++ b/pytrap/src/unirectemplate.h
@@ -26,6 +26,8 @@ PyAPI_FUNC(PyObject *) UnirecTemplate_setData(pytrap_unirectemplate *self, PyObj
 
 PyAPI_FUNC(PyObject *) UnirecTemplate_getDict(pytrap_unirectemplate *self);
 
+PyAPI_FUNC(PyObject *) UnirecTemplate_createMessage(pytrap_unirectemplate *self, uint32_t dynamic_size);
+
 PyAPI_FUNC(pytrap_unirectemplate *) UnirecTemplate_init(pytrap_unirectemplate *self);
 
 #ifdef __cplusplus

--- a/pytrap/src/unirectemplate.h
+++ b/pytrap/src/unirectemplate.h
@@ -11,6 +11,7 @@ typedef struct {
     Py_ssize_t data_size;
     PyObject *data_obj; // Pointer to object containing the data we are pointing to
     PyDictObject *urdict;
+    PyDictObject *fields_dict; // dictionary of field names indexed by field ID
 
     /* for iteration */
     Py_ssize_t iter_index;

--- a/pytrap/test/pytrapmodule_unittest.py
+++ b/pytrap/test/pytrapmodule_unittest.py
@@ -254,3 +254,32 @@ class SendAndReceiveMessageList(unittest.TestCase):
 
         os.unlink("/tmp/pytrap_test3")
 
+class SendBulkTest(unittest.TestCase):
+    def runTest(self):
+        import os
+        import pytrap
+
+        urtempl = "ipaddr IP,uint16 PORT"
+
+        # Start sender
+        c1 = pytrap.TrapCtx()
+        c1.init(["-i", "f:/tmp/pytrap_sendbulktest"], 0, 1)
+        c1.setDataFmt(0, pytrap.FMT_UNIREC, urtempl)
+        t = pytrap.UnirecTemplate(urtempl)
+        data = (
+            {"IP": "10.0.0.1", "PORT": 1},
+            {"IP": "10.0.0.2", "PORT": 2},
+            {"IP": "10.0.0.3", "PORT": 3},
+            {"IP": "10.0.0.4", "PORT": 4},
+            {"IP": "10.0.0.1", "PORT": 5},
+            {"IP": "10.0.0.2", "PORT": 6}
+        )
+
+        c1.sendBulk(t, data)
+
+        c1.sendFlush()
+
+        c1.finalize()
+
+        os.unlink("/tmp/pytrap_sendbulktest")
+        


### PR DESCRIPTION
Added new features:
* `UnirecTemplate.getFieldsDict()` has optional argument to create dict with field ID as keys
* `UnirecTemplate.setFromDict()` fills UniRec message using a dictionary with matching keys
* `TrapCtx.sendBulk()` sends a sequence of dictionaries (that are compatible with `setFromDict()`
* new helpers.py classes were introduced: `pytrap.helpers.PytrapHelperLoad()`, `pytrap.helpers.PytrapHelperStore()`; `read_nemea()` function was moved into helpers.py
* doc was improved and new features were added; there is a new doc "module" for helpers