### PR TITLE
pytrap: apply replacement on invalid utf-8 strings implicitly

### DIFF
--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -637,11 +637,7 @@ UnirecTemplate_get_local(pytrap_unirectemplate *self, char *data, int32_t field_
     case UR_TYPE_STRING:
         {
             Py_ssize_t value_size = ur_get_var_len(self->urtmplt, data, field_id);
-#if PY_MAJOR_VERSION >= 3
-            return PyUnicode_FromStringAndSize(value, value_size);
-#else
-            return PyString_FromStringAndSize(value, value_size);
-#endif
+            return PyUnicode_DecodeUTF8(value, value_size, "replace");
         }
         break;
     case UR_TYPE_BYTES:

--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -813,3 +813,29 @@ class AllocateBigMessage(unittest.TestCase):
         with self.assertRaises(pytrap.TrapError):
             a.createMessage(100000)
 
+class NonUtf8string(unittest.TestCase):
+    def runTest(self):
+        import pytrap
+        import time
+        a = pytrap.UnirecTemplate("string TEXT")
+        a.setData(b'\x00\x00\x08\x00\xf0abbccdd')
+        messages = 10000000
+        startt = time.process_time()
+        for i in range(messages):
+            b = a.TEXT
+        elapsed_time = time.process_time() - startt
+        print(f"Elapsed time for {messages} messages is: {elapsed_time}")
+
+class Utf8string(unittest.TestCase):
+    def runTest(self):
+        import pytrap
+        import time
+        a = pytrap.UnirecTemplate("string TEXT")
+        a.setData(b'\x00\x00\x08\x00aabbccdd')
+        messages = 10000000
+        startt = time.process_time()
+        for i in range(messages):
+            b = a.TEXT
+        elapsed_time = time.process_time() - startt
+        print(f"Elapsed time for {messages} messages is: {elapsed_time}")
+


### PR DESCRIPTION
Python string fails when non-utf8 bytes occure in the field value due to decoding error.
This patch replaces straightforward use of PyUnicode_FromStringAndSize() with
PyUnicode_DecodeUTF8(), which can be set to replace invalid bytes.

As a result, the invalid non-utf byte sequences are replaced by 0xFFFD character (dec ~ 65533).

It is worth noting that the replacement process affects performance (quite significantly).
On the other hand, valid UTF-8 strings perform similarly as before this PR.

