### PR TITLE
pytrap: fixed compilation issue for non-C99 standard

### DIFF
--- a/pytrap/src/pytrapmodule.c
+++ b/pytrap/src/pytrapmodule.c
@@ -274,7 +274,8 @@ pytrap_sendBulk(pytrap_trapcontext *self, PyObject *args, PyObject *keywds)
         Py_RETURN_NONE;
     }
 
-    for (Py_ssize_t i = 0; i < count; i++) {
+    Py_ssize_t i;
+    for (i = 0; i < count; i++) {
         PyObject *pydict = NULL;
         pydict = PySequence_GetItem(iterable, i);
 


### PR DESCRIPTION
for loops do not allow variable defininition without -std=c99 / -std=gnu99