### PR TITLE
libtrap: BUGFIX check return value of t_rb_at()

### DIFF
--- a/libtrap/ChangeLog
+++ b/libtrap/ChangeLog
@@ -1,3 +1,8 @@
+2023-08-28 libtrap-1.17.1
+	* BUGFIX: division by zero in JSON statistics
+	* BUGFIX: double close of the socket
+	* BUGFIX: double free of resources on finalization
+
 2023-01-25 libtrap-1.17.0
 	* libtrap: reworked buffers for tcp/unix and tls
 	* libtrap: file ifc flush last buffer before termination

--- a/libtrap/NEWS
+++ b/libtrap/NEWS
@@ -1,3 +1,11 @@
+2023-08-28 (Tomas Cejka): Merge pull request #206 from CESNET/bugfix_libtrap_linkedlist_removal
+2023-08-27 (Pavel Siska): libtrap: BUGFIX synchronize threads at exit
+2023-08-10 (Tomas Cejka): libtrap: BUGFIX potential double close of the socket
+2023-08-10 (Tomas Cejka): libtrap: BUGFIX proper removing clients from list
+2023-02-14 (SiskaPavel): Merge pull request #205 from CESNET/libtrap-tcpip-json-stats-fix
+2023-02-14 (Pavel Siska): Libtrap - ifc_tcpip - fix division by zero in json stats
+2023-01-25 (Tomas Cejka): Merge pull request #204 from CESNET/libtrap-new-version
+
 2023-01-25 (xsiska12): libtrap - update stats tool
 2023-01-25 (xsiska12): libtrap - reworked tcpip and tls internal buffers
 2023-01-23 (xsiska12): libtrap - file ifc - write last buffer to the file, before terminate

--- a/libtrap/configure.ac
+++ b/libtrap/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([libtrap], [1.17.0], [nemea@cesnet.cz])
+AC_INIT([libtrap], [1.17.1], [nemea@cesnet.cz])
 #for debug purposes:
 #AM_INIT_AUTOMAKE([-Wall -Werror])
 AM_INIT_AUTOMAKE([subdir-objects no-dependencies])

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1126,6 +1126,10 @@ send_blocking_mode(void *arg)
 
       // get next container
       t_cont = t_rb_at(&c->t_mbuf.to_send, cl->container_id);
+      if (t_cont == NULL) {
+         // we cannot operate with NULL t_cont
+         continue;
+      }
           
       buffer = t_cont->buffer;
       pending_bytes = t_cont->used_bytes;
@@ -1192,6 +1196,10 @@ again_set_container:
           
       // get next container
       t_cont = t_rb_at(&c->t_mbuf.to_send, cl->container_id);
+      if (t_cont == NULL) {
+         // we cannot operate with NULL t_cont
+         continue;
+      }
 
       // container is no longer available
       if (t_cont_acquiere(t_cont) < 1 || __sync_fetch_and_add(&t_cont->idx, 0) != cl->container_id) {

--- a/libtrap/src/ifc_tcpip.c
+++ b/libtrap/src/ifc_tcpip.c
@@ -1118,8 +1118,8 @@ send_blocking_mode(void *arg)
          if (c->is_terminated) {
             break;
          }
-        	sleep_time = calculate_sleep(sleep_time);
-        	usleep(sleep_time);
+         sleep_time = calculate_sleep(sleep_time);
+         usleep(sleep_time);
       }
 
       sleep_time = 1;

--- a/libtrap/src/ifc_tls.c
+++ b/libtrap/src/ifc_tls.c
@@ -1313,6 +1313,10 @@ send_blocking_mode(void *arg)
 
       // get next container
       t_cont = t_rb_at(&c->t_mbuf.to_send, cl->container_id);
+      if (t_cont == NULL) {
+         // we cannot operate with NULL t_cont
+         continue;
+      }
           
       buffer = t_cont->buffer;
       pending_bytes = t_cont->used_bytes;
@@ -1379,6 +1383,10 @@ again_set_container:
           
       // get next container
       t_cont = t_rb_at(&c->t_mbuf.to_send, cl->container_id);
+      if (t_cont == NULL) {
+         // we cannot operate with NULL t_cont
+         continue;
+      }
 
       // container is no longer available
       if (t_cont_acquiere(t_cont) < 1 || __sync_fetch_and_add(&t_cont->idx, 0) != cl->container_id) {


### PR DESCRIPTION
If t_rb_at() returns NULL, we cannot access its content (such as the
buffer or ref_counter).  There is currently continue after this test to
go back to the start of the loop and check is_terminated.