### PR TITLE
pytrap: add capability to set arrays from dict

### DIFF
--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -1523,7 +1523,7 @@ UnirecTemplate_setFromDict(pytrap_unirectemplate *self, PyObject *dict, int skip
                     Py_DECREF(idkey);
                     return NULL;
                 }
-            } else if (PyLong_Check(v)) {
+            } else if (PyLong_Check(v) || PySequence_Check(v)) {
                 if (UnirecTemplate_set_local(self, self->data, id, v) == NULL) {
                     Py_DECREF(idkey);
                     return NULL;

--- a/pytrap/src/unirecmodule.c
+++ b/pytrap/src/unirecmodule.c
@@ -1523,7 +1523,7 @@ UnirecTemplate_setFromDict(pytrap_unirectemplate *self, PyObject *dict, int skip
                     Py_DECREF(idkey);
                     return NULL;
                 }
-            } else if (PyLong_Check(v) || PySequence_Check(v)) {
+            } else {
                 if (UnirecTemplate_set_local(self, self->data, id, v) == NULL) {
                     Py_DECREF(idkey);
                     return NULL;

--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -842,10 +842,12 @@ class Utf8string(unittest.TestCase):
 class ArrayFromDict(unittest.TestCase):
     def runTest(self):
         import pytrap
-        rec = pytrap.UnirecTemplate("int8* PPI_PKT_DIRECTIONS,uint8* PPI_PKT_FLAGS,uint16* PPI_PKT_LENGTHS,uint32* DBI_BRST_BYTES,time* DBI_BRST_TIME_START")
+        rec = pytrap.UnirecTemplate("int8* PPI_PKT_DIRECTIONS,uint8* PPI_PKT_FLAGS,uint16* PPI_PKT_LENGTHS,uint32* DBI_BRST_BYTES,time* DBI_BRST_TIME_START,ipaddr SRC_IP,time TIME")
         rec.createMessage(10000)
         # prepare dict
         data = {
+                  "SRC_IP": pytrap.UnirecIPAddr("10.0.0.1"),
+                  "TIME": pytrap.UnirecTime(1669885132, 853),
                   "PPI_PKT_DIRECTIONS": [
                     1, -1, -1, -1, -1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                     -1, -1, -1, -1, -1, -1, -1, 1, -1, -1

--- a/pytrap/test/unirectemplate_unittest.py
+++ b/pytrap/test/unirectemplate_unittest.py
@@ -839,3 +839,39 @@ class Utf8string(unittest.TestCase):
         elapsed_time = time.process_time() - startt
         print(f"Elapsed time for {messages} messages is: {elapsed_time}")
 
+class ArrayFromDict(unittest.TestCase):
+    def runTest(self):
+        import pytrap
+        rec = pytrap.UnirecTemplate("int8* PPI_PKT_DIRECTIONS,uint8* PPI_PKT_FLAGS,uint16* PPI_PKT_LENGTHS,uint32* DBI_BRST_BYTES,time* DBI_BRST_TIME_START")
+        rec.createMessage(10000)
+        # prepare dict
+        data = {
+                  "PPI_PKT_DIRECTIONS": [
+                    1, -1, -1, -1, -1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                    -1, -1, -1, -1, -1, -1, -1, 1, -1, -1
+                  ],
+                  "PPI_PKT_FLAGS": [
+                    24, 16, 24, 16, 24, 24, 24, 24, 24, 24, 24, 24, 16, 24, 16, 24, 16, 24, 16,
+                    24, 16, 24, 16, 24, 16, 24, 16, 24, 24, 16
+                  ],
+                  "PPI_PKT_LENGTHS": [
+                    517, 1400, 1400, 1400, 282, 74, 98, 416, 978, 31, 590, 1400, 1400, 1400,
+                    1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400,
+                    1400, 31, 1400, 1400
+                  ],
+                  "DBI_BRST_BYTES": [
+                    71274
+                  ],
+                  "DBI_BRST_TIME_START": [
+                    pytrap.UnirecTime(1669885132, 853),
+                    pytrap.UnirecTime(1669985132, 853)
+                  ]
+              }
+
+        # set it into UnirecTemplate
+        rec.setFromDict(data)
+        # get the content
+        stored = rec.getDict()
+        # compare it
+        self.assertEqual(stored, data)
+


### PR DESCRIPTION
UniRec arrays were not set in UnirecTemplate.setFromDict() due to
missing check for value sequence.

New test ArrayFromDict was prepared to check this feature.
