### PR TITLE
Changes in tmp files

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,10 +31,11 @@ jobs:
       run: make check
     - name: make distcheck
       run: make distcheck
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v4
       with:
         flags: tests # optional
         name: nemea-framework # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
+        token: ${{ secrets.CODECOV_TOKEN }} # required
 

--- a/libtrap/libtrap-varrun.conf.in
+++ b/libtrap/libtrap-varrun.conf.in
@@ -1,1 +1,1 @@
-D @defaultsocketdir@ 0777 root root -
+D @defaultsocketdir@ 1777 root root -

--- a/libtrap/libtrap-varrun.conf.in
+++ b/libtrap/libtrap-varrun.conf.in
@@ -1,1 +1,1 @@
-D @defaultsocketdir@ 0777 nemead nemead -
+D @defaultsocketdir@ 0777 root root -

--- a/libtrap/libtrap.spec.in
+++ b/libtrap/libtrap.spec.in
@@ -31,7 +31,7 @@ if you want to develop your own TRAP module.
 %setup
 
 %build
-./configure --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --docdir=%{_docdir}/libtrap --with-defaultsocketdir=%{_localstatedir}/run/libtrap --disable-doxygen-pdf --disable-doxygen-ps --disable-tests -q;
+./configure --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --docdir=%{_docdir}/libtrap --with-defaultsocketdir=%{_rundir}/libtrap --disable-doxygen-pdf --disable-doxygen-ps --disable-tests -q;
 make -j5
 make doc
 
@@ -47,7 +47,7 @@ ldconfig
 %{_libdir}/libtrap.so.*
 %{_sysconfdir}/tmpfiles.d/libtrap-varrun.conf
 %defattr(-,-,-,1777)
-%dir %{_localstatedir}/run/libtrap
+%dir %{_rundir}/libtrap
 
 %files devel
 %{_libdir}/pkgconfig/libtrap.pc


### PR DESCRIPTION
- We have changed ownership from nemead to root to maintain functionality even without nemea-supervisor
- /var/run/libtrap changed to /run/libtrap since /var/run is deprecated
- Added sticky bit permission for the tmp files directory