### PR TITLE
pytrap: fixed doc config

### DIFF
--- a/pytrap/docs/conf.py
+++ b/pytrap/docs/conf.py
@@ -52,6 +52,7 @@ language = 'en'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+master_doc = 'index'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This PR enforces master_doc to index to fix doc on rockylinux8 with apparently old sphinx.