### PR TITLE
pytrap: raise type error on incorrect type

### DIFF
--- a/pytrap/src/unirecipaddr.c
+++ b/pytrap/src/unirecipaddr.c
@@ -480,7 +480,8 @@ UnirecIPAddrRange_isIn(pytrap_unirecipaddrrange *self, PyObject *args)
     PyObject *result = Py_False;
 
     if (!PyObject_IsInstance(args, (PyObject *) &pytrap_UnirecIPAddr)) {
-        result = Py_NotImplemented;
+        PyErr_Format(PyExc_TypeError, "UnirecIPAddr object expected, got '%s'.", Py_TYPE(args)->tp_name);
+        return NULL;
     }
 
     int cmp_result;
@@ -520,7 +521,8 @@ UnirecIPAddrRange_isOverlap(pytrap_unirecipaddrrange *self, PyObject *args)
         return NULL;
 
     if (!PyObject_IsInstance((PyObject*)other, (PyObject *) &pytrap_UnirecIPAddrRange)) {
-        return Py_NotImplemented;
+        PyErr_Format(PyExc_TypeError, "UnirecIPAddrRange object expected, got '%s'.", Py_TYPE(other)->tp_name);
+        return NULL;
     }
 
     tmp = UnirecIPAddrRange_isIn(self, (PyObject *) other->start);
@@ -537,6 +539,11 @@ UnirecIPAddrRange_isOverlap(pytrap_unirecipaddrrange *self, PyObject *args)
 static int
 UnirecIPAddrRange_contains(pytrap_unirecipaddrrange *o, pytrap_unirecipaddr *ip)
 {
+    if (!PyObject_IsInstance((PyObject *) ip, (PyObject *) &pytrap_UnirecIPAddr)) {
+        PyErr_Format(PyExc_TypeError, "UnirecIPAddr object expected, got '%s'.", Py_TYPE(ip)->tp_name);
+        return -1;
+    }
+
     PyObject * tmp = UnirecIPAddrRange_isIn(o, (PyObject *) ip);
     int cmp_result = PyLong_AsLong(tmp);
     Py_DECREF(tmp);


### PR DESCRIPTION
Fixes incorrect behavior of `UnirecIPAddrRange.__contains__` due to incomplete type checking:

Previous behavior
```py
from pytrap import UnirecIPAddrRange, UnirecIPAddr
r = UnirecIPAddrRange("192.168.42.0/24")
a = UnirecIPAddr("192.168.42.42")
print(a in r)       # True, OK
print(str(a) in r)  # False, should TypeError
print(42 in r)      # False, should TypeError
```

New behavior
```py
from pytrap import UnirecIPAddrRange, UnirecIPAddr
r = UnirecIPAddrRange("192.168.42.0/24")
a = UnirecIPAddr("192.168.42.42")
print(a in r)       # True, OK
print(str(a) in r)  # TypeError: pytrap.UnirecIPAddrRange object expected, got 'str'.
print(42 in r)      # TypeError: pytrap.UnirecIPAddrRange object expected, got 'int'.
```

Also fixes adjacent behavior of `UnirecIPAddrRange.isOverlap` and `UnirecIPAddrRange.isIn`.

Previously:
```py
from pytrap import UnirecIPAddrRange, UnirecIPAddr
r = UnirecIPAddrRange("192.168.42.0/24")
r2 = UnirecIPAddrRange("192.168.42.128/25")
a = UnirecIPAddr("192.168.42.42")

print(r.isOverlap(r2))        # True, OK
print(r.isOverlap(r2.start))  # NotImplemented, not great because bool(NotImplemented) is True
print(r.isOverlap(42))        # NotImplemented again.

print(r.isIn(a))       # 0, OK
print(r.isIn(str(a)))  # 1, should TypeError
print(r.isIn(0))       # 1, should TypeError
```

New behavior
```py
from pytrap import UnirecIPAddrRange, UnirecIPAddr
r = UnirecIPAddrRange("192.168.42.0/24")
r2 = UnirecIPAddrRange("192.168.42.128/25")
a = UnirecIPAddr("192.168.42.42")

print(r.isOverlap(r2))        # True, OK
print(r.isOverlap(r2.start))  # TypeError: UnirecIPAddrRange object expected, got 'pytrap.UnirecIPAddr'.
print(r.isOverlap(42))        # TypeError: UnirecIPAddrRange object expected, got 'int'.

print(r.isIn(a))       # 0, OK
print(r.isIn(str(a)))  # TypeError: UnirecIPAddr object expected, got 'str'.
print(r.isIn(0))       # TypeError: UnirecIPAddr object expected, got 'int'.
```