### PR TITLE
Replace pynspect with ransack

### DIFF
--- a/pycommon/reporter_config/Rule.py
+++ b/pycommon/reporter_config/Rule.py
@@ -1,10 +1,7 @@
 import re
 import logging
 import redis
-#from pynspect.rules import *
-from pynspect.filters import DataObjectFilter
-from pynspect.compilers import IDEAFilterCompiler
-from pynspect.gparser import PynspectFilterParser
+from ransack import Parser, Filter
 from idea import lite
 
 logger = logging.getLogger(__name__)
@@ -41,7 +38,7 @@ def clearCounters(prefix, module):
         logging.error("redis: Could not update statistics.")
 
 class Rule():
-    def __init__(self, rule, actions, addrGroups, parser=None, compiler=None, module_name=""):
+    def __init__(self, rule, actions, parser=None, module_name=""):
 
         if not "condition" in rule:
             raise SyntaxError("Missing 'condition' in the rule: " + str(rule))
@@ -49,33 +46,25 @@ class Rule():
         if not "id" in rule:
             raise SyntaxError("Missing 'id' in the rule: " + str(rule))
 
-        # Check is we got parser instance
+        # Check if we got parser instance
         if parser is None:
-            self.parser = PynspectFilterParser()
-            self.parser.build()
+            self.parser = Parser()
         else:
             self.parser = parser
 
-        # Check is we got compiler instance
-        if compiler is None:
-            self.compiler = IDEAFilterCompiler()
-        else:
-            self.compiler = compiler
-
         # Instantiate filter
-        self.__filter = DataObjectFilter()
+        self.__filter = Filter()
 
 
         # Store rule condition in raw form
         self.__conditionRaw = rule["condition"]
 
-        if not self.__matchvar(rule["condition"], addrGroups):
-            self.__condition = self.__conditionRaw
-
         self.module_name = module_name
         # Set inner rule ID
         self.id = rule["id"]
 
+        # Store the parsed condition
+        self.__condition = self.__conditionRaw
         if (self.__condition != None):
             self.parseRule()
 
@@ -109,7 +98,6 @@ class Rule():
         else:
             try:
                 self.__condition = self.parser.parse(self.__condition)
-                self.__condition = self.compiler.compile(self.__condition)
             except Exception as e:
                 raise SyntaxError("Error while parsing condition: {0}\nOriginal exception: {1}".format(self.__condition, e))
 
@@ -136,7 +124,7 @@ class Rule():
             res = False
         else:
             # Match the record with non-empty rule's condition
-            res = self.__filter.filter(self.__condition, record)
+            res = self.__filter.eval(self.__condition, record)
 
         logger.debug("RESULT: %s", res)
 
@@ -184,28 +172,4 @@ class Rule():
 
     def rule(self):
         return str(self.__condition)
-
-    def __matchvar(self, rule, addrGroups):
-        """
-        Since pyncspect doesn't support variables yet we had to provide
-        a solution where every address group's name is matched against
-        the rule's condition and eventually replaced with address group's values
-        """
-
-        matched = False
-
-        """
-        Tautology - empty rule should always match
-        Don't try to match or replace any address group
-        """
-        if rule is None or isinstance(rule, bool):
-            return False
-
-        for key in addrGroups:
-            if key in rule:
-                rule = re.sub(r"\b{0}\b".format(re.escape(key)), addrGroups[key].iplist(), rule)
-                matched = True
-        self.__condition = rule
-
-        return matched
 

--- a/pycommon/test/rc_config/iprange_stdout.yaml
+++ b/pycommon/test/rc_config/iprange_stdout.yaml
@@ -6,21 +6,21 @@ custom_actions:
       path: /dev/stdout
 rules:
   - id: 1
-    condition: Source.IP4 in [ "192.168.0.0/24" ]
+    condition: Source.IP4 in 192.168.0.0/24
     actions:
       - stdout
 
   - id: 1
-    condition: Source.IP4 in [ "192.168.1.0/24" ]
+    condition: Source.IP4 in 192.168.1.0/24
     actions:
       - stdout
 
   - id: 1
-    condition: Source.IP4 in [ "10.0.0.0/8" ]
+    condition: Source.IP4 in 10.0.0.0/8
     actions:
       - stdout
 
   - id: 1
-    condition: Source.IP4 in [ "10.1.0.0/16" ]
+    condition: Source.IP4 in 10.1.0.0/16
     actions:
       - stdout


### PR DESCRIPTION
Since pynspect is no longer supported and it has several drawbacks, a new parsing library was created - [ransack](https://gitlab.cesnet.cz/713/mentat/ransack).