### PR TITLE
unirec++: skip type check for std::byte fields in UnirecRecord

### DIFF
--- a/unirec/include/unirec++/unirecRecord.hpp
+++ b/unirec/include/unirec++/unirecRecord.hpp
@@ -339,7 +339,9 @@ private:
 		if (ur_is_array(fieldID)) {
 			expectedType = getExpectedUnirecType<RequiredType*>();
 		} else {
-			expectedType = getExpectedUnirecType<RequiredType>();
+			if constexpr (!std::is_same_v<RequiredType, std::byte>) {
+				expectedType = getExpectedUnirecType<RequiredType>();
+			}
 		}
 
 		if (expectedType != ur_get_type(fieldID)) {


### PR DESCRIPTION
Avoid calling getExpectedUnirecType for std::byte fields in checkDataTypeCompatibility(), since byte buffers are handled as raw data and don't have a defined Unirec type mapping.